### PR TITLE
Remove metafits dependence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,16 +157,6 @@ set(target_convert "${CONVERTWSCLEAN}/convert_WSClean_list_to_WODEN.py")
 ADD_CUSTOM_TARGET(target_convert ALL
                   COMMAND ${CMAKE_COMMAND} -E create_symlink ${target_convert} ${link_convert})
 
-##Make a symlink to the tempate MWA uvfits so it's easy to find
-set(link_uvfits "template_MWA_128T.uvfits")
-find_path(UVFITS_DIR template_MWA_128T.uvfits HINTS "${CMAKE_CURRENT_LIST_DIR}/templates/")
-if(UVFITS_DIR)
-  message(STATUS "UVFITS_DIR path: ${UVFITS_DIR}")
-endif()
-set(target_uvfits "${UVFITS_DIR}/template_MWA_128T.uvfits")
-ADD_CUSTOM_TARGET(target_uvfits ALL
-                  COMMAND ${CMAKE_COMMAND} -E create_symlink ${target_uvfits} ${link_uvfits})
-
 ##Copy the variable init script so this file can be put in bashrc
 find_path(INIT_WODEN init_WODEN.sh HINTS "${CMAKE_CURRENT_LIST_DIR}/templates/")
 if(INIT_WODEN)

--- a/include/constants.h
+++ b/include/constants.h
@@ -7,7 +7,7 @@
 #define D2R M_PI/180.0
 #define DEFAULT_SI -0.8
 #define MWA_LAT -26.703319
-#define MWA_LAT_RAD -26.703319*(M_PI / 180.)
+#define MWA_LAT_RAD -26.703319*DD2R
 #define M_PI_2_2_LN_2 7.11941466249375271693034 /* pi^2 / (2 log_e(2)) */
 #define SQRT_M_PI_2_2_LN_2 2.668223128318498282851579 /* sqrt(pi^2 / (2 log_e(2)))*/
 #define FWHM_FACTOR 2.35482004503

--- a/include/primary_beam.h
+++ b/include/primary_beam.h
@@ -6,9 +6,4 @@ void calc_para_angle(catsource_t *cropped_src, float *lsts,
                      int num_time_steps);
 
 beam_settings_t fill_primary_beam_settings(woden_settings_t *woden_settings,
-                MetaFfile_t metafits, catsource_t *cropped_src,
-                float *lsts, int num_time_steps);
-
-//TODO make this work so we can pull it out of woden.c
-// void setup_FEE_beam(woden_settings_t *woden_settings, MetaFfile_t metafits,
-//                     beam_settings_t beam_settings, float base_middle_freq);
+                catsource_t *cropped_src,  float *lsts, int num_time_steps);

--- a/include/primary_beam_cuda.h
+++ b/include/primary_beam_cuda.h
@@ -3,14 +3,14 @@ __device__ void twoD_Gaussian(float x, float y, float xo, float yo,
            float * d_beam_real, float * d_beam_imag);
 
 __global__ void kern_gaussian_beam(float *d_beam_ls, float *d_beam_ms,
-           float *ref_freq, float *d_freqs,
+           float beam_ref_freq, float *d_freqs,
            float fwhm_lm, float cos_theta, float sin_theta, float sin_2theta,
            int num_freqs, int num_times, int num_components,
            cuFloatComplex *d_primay_beam_J00, cuFloatComplex *d_primay_beam_J11);
 
 extern "C" void calculate_gaussian_beam(int num_points, int num_time_steps, int num_freqs,
      float fwhm_lm, float cos_theta, float sin_theta, float sin_2theta,
-     float *d_beam_ref_freq, float *d_freqs, float *d_beam_angles_array,
+     float beam_ref_freq, float *d_freqs, float *d_beam_angles_array,
      float *beam_point_has, float *beam_point_decs,
      cuFloatComplex *d_primay_beam_J00, cuFloatComplex *d_primay_beam_J11);
 

--- a/include/read_and_write.h
+++ b/include/read_and_write.h
@@ -131,7 +131,6 @@ typedef struct _woden_settngs_t {
   int num_time_steps;
   float time_res;
   const char* cat_filename;
-  const char* metafits_filename;
   int num_bands;
   int *band_nums;
   int sky_crop_type;
@@ -144,6 +143,13 @@ typedef struct _woden_settngs_t {
   int EDA2_sim;
   int array_layout_file;
   char* array_layout_file_path;
+  float latitude;
+  float longitude;
+  float FEE_ideal_delays[16];
+  float coarse_band_width;
+  float gauss_ra_point;
+  float gauss_dec_point;
+
 
 } woden_settings_t;
 
@@ -163,44 +169,41 @@ typedef struct _array_layout_t {
     float lst_base;
 } array_layout_t;
 
-// Taken from the RTS (Mitchell et al 2008)
-// All credit to the original authors
-// https://github.com/ICRAR/mwa-RTS.git
-typedef struct _Meta_Ffile {
-    char recvrs[38];
-    char calib[1];
-    char calsrc[16];
-    char tileflg[16];
-    char version[4];
-    char mwaVersion;
-    long naxes[2];
-    int inps[256], ants[256], tile[256], flags[256];
-    float E[256], N[256], H[256];
-    char leng[256][14];
-    int FEE_delays[256][16];
-    int dig_gains[256][24];
-    int centchan;
-    float lst_base;
-    float ra_point;
-    float dec_point;
-    float frequency_resolution;
-    float frequency_cent;
-    float bandwidth;
-    float base_low_freq;
-    float time_res;
-    int num_tiles;
-    int FEE_ideal_delays[16];
-
-} MetaFfile_t;
+// // Taken from the RTS (Mitchell et al 2008)
+// // All credit to the original authors
+// // https://github.com/ICRAR/mwa-RTS.git
+// typedef struct _Meta_Ffile {
+//     char recvrs[38];
+//     char calib[1];
+//     char calsrc[16];
+//     char tileflg[16];
+//     char version[4];
+//     char mwaVersion;
+//     long naxes[2];
+//     int inps[256], ants[256], tile[256], flags[256];
+//     float E[256], N[256], H[256];
+//     char leng[256][14];
+//     int FEE_delays[256][16];
+//     int dig_gains[256][24];
+//     int centchan;
+//     float lst_base;
+//     float ra_point;
+//     float dec_point;
+//     float frequency_resolution;
+//     float frequency_cent;
+//     float bandwidth;
+//     float base_low_freq;
+//     float time_res;
+//     int num_tiles;
+//     int FEE_ideal_delays[16];
+//
+// } MetaFfile_t;
 
 source_catalogue_t * read_source_catalogue(const char *filename);
 
 woden_settings_t * read_json_settings(const char *filename);
 
-int RTS_init_meta_file(fitsfile *mfptr, MetaFfile_t *metafits, woden_settings_t *woden_settings);
-
-array_layout_t * calc_XYZ_diffs(MetaFfile_t *metafits,
-                                woden_settings_t *woden_settings);
+array_layout_t * calc_XYZ_diffs(woden_settings_t *woden_settings);
 
 typedef struct _beam_settings_t {
     float *beam_angles_array;
@@ -217,7 +220,8 @@ typedef struct _beam_settings_t {
     int num_shape_beam_values;
 
     float beam_FWHM_rad;
-    float *beam_ref_freq_array;
+    // float *beam_ref_freq_array;
+    float beam_ref_freq;
     int beamtype;
 
     float *para_cosrot;

--- a/src/chunk_sources.c
+++ b/src/chunk_sources.c
@@ -405,8 +405,7 @@ beam_settings_t make_beam_settings_chunk(beam_settings_t beam_settings,
     //Set constants used in beam calculation
     beam_settings_chunk.beam_FWHM_rad = beam_settings.beam_FWHM_rad;
 
-    beam_settings_chunk.beam_ref_freq_array = malloc(sizeof(float));
-    beam_settings_chunk.beam_ref_freq_array = beam_settings.beam_ref_freq_array;
+    beam_settings_chunk.beam_ref_freq = beam_settings.beam_ref_freq;
 
     //Store all ha (which change with lst) that the beam needs to be calculated at.
     beam_settings_chunk.beam_point_has = malloc(woden_settings->num_time_steps * temp_cropped_src->n_points * sizeof(float));

--- a/src/print_help.c
+++ b/src/print_help.c
@@ -2,16 +2,47 @@
 
 void print_cmdline_help() {
   printf("Must input a .json settings file to run woden. This file must include:\n");
-  printf("\tra0: ra phase centre (float in degrees)\n");
-  printf("\tdec0: dec phase centre (float in degrees)\n");
-  printf("\tnum_freqs: number of fine frequency channels to simulate (int)\n");
-  printf("\tnum_time_steps: number of time steps to simulate (int)\n");
-  printf("\tcat_filename: path to and name of WODEN-style srclist (string)\n");
-  printf("\tmetafits_filename: path to MWA and name of metafits file to base\n\t\tsimulation on (string)\n");
+  printf("\t+ ra0: RA phase centre (float in degrees)\n");
+  printf("\t+ dec0: Dec phase centre (float in degrees)\n");
+  printf("\t+ num_freqs: number of fine frequency channels to simulate (int)\n");
+  printf("\t+ num_time_steps: number of time steps to simulate (int)\n");
+  printf("\t+ cat_filename: path to and name of WODEN-style srclist (string)\n");
+  printf("\t+ time_res: Time resolution (s) of the simulation\n");
+  printf("\t+ frequency_resolution: Fine channel frequnecy resolution (Hz)\n");
+  printf("\t+ jd_date: Julian date of the start of the observation\n");
+  printf("\t+ LST: Local Sidereal Time at the start of the observation\n");
+  printf("\t+ array_layout: Layout of the array in East, North, Height coords\n");
+      printf("\t\t(meters)\n");
+  printf("\t+ lowest_channel_freq\n");
+  printf("\t+ latitude: Latitude (deg) of the array\n");
+  printf("\t+ longitude: Longitude (deg) of the array\n");
+  printf("\t+ coarse_band_width: the frequency bandwidth of each band (Hz)\n");
+
+  printf("\t+ band_nums: an array of which band numbers to simulate (ints) \n");
+
   printf("\n");
+
   printf("Optionally, the .json can include:\n");
-  printf("\tsky_crop_components=True: WODEN crops sources with any component\n\t\tbelow the horizon. Add this arg to include all components\n\t\tabove horizon, regardless of which source they belong to\n");
-  printf("\tuse_gaussian_beam=True: Use a gaussian primary beam in the simulation\n\t\tpointed at the RA,DEC pointing specified in the metafits file\n");
-  printf("\tgauss_beam_FWHM: Sets the FWHM of the gaussian primary beam (degrees)\n");
-  printf("\tgauss_beam_ref_freq: The frequency (Hz) at which gauss_beam_FWHM is set\n\t\tThe beam FWHM will scale with frequency about this reference\n");
+  printf("\t+ use_FEE_beam: use the MWA FEE primary beam model\n");
+  printf("\t+ hdf5_beam_path: Location of the hdf5 file holding the FEE beam\n");
+      printf("\t\t coefficients\n");
+  printf("\t+ FEE_delays: A array of 16 delays to point the MWA FEE primary beam\n");
+      printf("\t\t model\n");
+
+  printf("\t+ use_gaussian_beam=True: Use a gaussian primary beam in the\n");
+      printf("\t\tsimulation pointed at the RA,DEC specified by --gauss_ra_point\n");
+      printf("\t\tand --gauss_dec_point\n");
+  printf("\t+ gauss_beam_FWHM: Sets the FWHM of the gaussian primary beam (degrees)\n");
+  printf("\t+ gauss_beam_ref_freq: The frequency (Hz) at which gauss_beam_FWHM is\n");
+      printf("\t\tsetThe beam FWHM will scale with frequency about this reference\n");
+  printf("\t+ gauss_ra_point: The initial RA (deg) to point the Gaussian beam at\n");
+  printf("\t+ gauss_dec_point: he initial Dec (deg) to point the Gaussian beam at\n");
+
+  printf("\t+ use_EDA2_beam: Use the EDA2 beam (Analytic dipole with a ground mesh)\n");
+
+  printf("\t+ sky_crop_components=True: WODEN crops sources with any component\n");
+      printf("\t\tbelow the horizon. Add this arg to include all components\n");
+      printf("\t\tabove horizon, regardless of which source they belong to\n");
+  printf("\t+ chunking_size: The chunk size to break up the point sources into \n");
+      printf("\t\tfor processing\n");
 }


### PR DESCRIPTION
The main woden executable now no longer needs a metafits file, so is more flexible. Can still read in all the settings from a metafits using run_woden.py.