### PR TITLE
Auto correlations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ test_installation/absolute_accuracy/uvfits
 *__pycache__/
 *.ms
 
+examples/MWA_EoR0
+test_installation/curved_power_law
+test_installation/list_fluxes
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,8 @@ if(TARGET_GROUP STREQUAL production)
     endmacro(make_python_symlink)
 
     make_python_symlink("run_woden.py")
+    make_python_symlink("add_woden_uvfits.py")
+    make_python_symlink("concat_woden_uvfits.py")
     make_python_symlink("uv2ms.py")
     make_python_symlink("convert_WSClean_list_to_WODEN.py")
 
@@ -238,6 +240,8 @@ if(TARGET_GROUP STREQUAL production)
     endmacro(install_symlink)
 
     install_symlink("run_woden.py")
+    install_symlink("add_woden_uvfits.py")
+    install_symlink("concat_woden_uvfits.py")
     install_symlink("uv2ms.py")
     install_symlink("convert_WSClean_list_to_WODEN.py")
 

--- a/cmake_testing/CMakeLists.txt
+++ b/cmake_testing/CMakeLists.txt
@@ -44,11 +44,13 @@ add_subdirectory(shapelet_basis)
 add_subdirectory(woden_settings)
 
 
-##Test CUDA code
+###Test CUDA code
 add_subdirectory(calculate_visibilities)
 add_subdirectory(fundamental_coords)
 add_subdirectory(primary_beam_cuda)
 add_subdirectory(source_components)
 
-###Test python code
+####Test python code
 add_subdirectory(run_woden)
+add_subdirectory(add_woden_uvfits)
+add_subdirectory(concat_woden_uvfits)

--- a/cmake_testing/add_woden_uvfits/CMakeLists.txt
+++ b/cmake_testing/add_woden_uvfits/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+include(FindPythonInterp)
+
+##Set an environment variable for the ctest of this, so we can find a path
+##to some test files that live in this dir
+add_test(python_test_add_woden_uvfits ${PYTHON_EXECUTABLE}
+         ${CMAKE_CURRENT_SOURCE_DIR}/test_add_woden_uvfits.py)
+set_tests_properties(python_test_add_woden_uvfits PROPERTIES
+         ENVIRONMENT CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR})

--- a/cmake_testing/add_woden_uvfits/test_add_woden_uvfits.py
+++ b/cmake_testing/add_woden_uvfits/test_add_woden_uvfits.py
@@ -1,0 +1,408 @@
+from sys import path
+import os
+import unittest
+import numpy as np
+from astropy.io import fits
+from unittest import mock
+import argparse
+
+##This is where our code lives
+code_dir = os.environ['CMAKE_CURRENT_SOURCE_DIR']
+
+##Append the location of run_woden.py to the sys.path to import it
+path.append('{:s}/../../src'.format(code_dir))
+
+##Code we are testing
+import run_woden as rw
+import add_woden_uvfits as awu
+
+##Vehicle for running tests
+class Test(unittest.TestCase):
+    def make_dummy_intputs(self):
+        """Makes some inputs used to pass to rw.create_uvfits"""
+        self.date = "2019-06-12T13:04:12"
+        self.gst0_deg = 260.0303917560829
+        self.degpdy = 360.98563614850775
+        self.ut1utc = -0.17421478816666666
+        self.num_antennas = 10
+        self.freq_cent = 160e+6
+        self.telescope_name = "MWA"
+        self.longitude = 116.670813889
+        self.latitude = -26.7033194444
+        self.array_height = 377.0
+        self.central_freq_chan = 2
+        self.ch_width = 40e3
+        self.ra_point = 0.0
+        self.dec_point = -26.7
+        self.num_baselines = int(((self.num_antennas - 1)*self.num_antennas) / 2)
+        self.num_time_steps = 2
+        self.num_freq_channels = 3
+        self.int_jd = 2458647.0
+        self.gitlabel = 'as987has'
+        self.XYZ_array = np.arange(self.num_antennas*3)
+        self.XYZ_array.shape = (self.num_antennas, 3)
+        self.output_uvfits_name = "unittest_example1_band01.uvfits"
+
+    def create_uvfits_outputs(self, num_freqs=3):
+        """Tests the `rw.create_uvfits` function, which should take a whole
+        heap of inputs and write out a uvits. Test by running funciton,
+        reading in the created file and checking contents"""
+
+        self.num_freq_channels = num_freqs
+
+        ##Some input test params
+        # self.make_dummy_intputs()
+
+        ##Create an antenna table
+        ant_table = rw.make_antenna_table(XYZ_array=self.XYZ_array,
+                      telescope_name=self.telescope_name,
+                      num_antennas=self.num_antennas, freq_cent=self.freq_cent,
+                      date=self.date, gst0_deg=self.gst0_deg,
+                      degpdy=self.degpdy, ut1utc=self.ut1utc,
+                      longitude=self.longitude, latitude=self.latitude,
+                      array_height=self.array_height)
+
+        ##Create some dummy data inputs
+        v_container = np.ones((self.num_time_steps*self.num_baselines, 1, 1, self.num_freq_channels, 4, 3))
+        # random_data = np.random.uniform(-10000, 10000, self.num_time_steps*self.num_baselines*self.num_freq_channels*4*3)
+        # random_data.shape = (self.num_time_steps*self.num_baselines, self.num_freq_channels, 4, 3)
+        # v_container[:,0,0,:,:,:] = random_data
+
+        uu = np.arange(self.num_baselines*self.num_time_steps)
+        vv = np.arange(self.num_baselines*self.num_time_steps) + self.num_baselines
+        ww = np.arange(self.num_baselines*self.num_time_steps) + 2*self.num_baselines
+        baselines_array = np.arange(self.num_baselines*self.num_time_steps)
+
+        date_array = np.ones(self.num_time_steps*self.num_baselines)*0.04458333319
+        ##Add a second of time onto the second half of the date array
+        date_array[self.num_baselines:] += (1 / (24.0*60.0*60.0))
+
+        rw.create_uvfits(freq_cent=self.freq_cent, ch_width=self.ch_width,
+                  central_freq_chan=self.central_freq_chan,
+                  ra_point=self.ra_point, dec_point=self.dec_point,
+                  output_uvfits_name=self.output_uvfits_name,
+                  int_jd=self.int_jd, gitlabel=self.gitlabel,
+                  v_container=v_container,
+                  uu=uu, vv=vv, ww=ww,
+                  baselines_array=baselines_array, date_array=date_array,
+                  hdu_ant=ant_table, telescope_name=self.telescope_name,
+                  longitude=self.longitude, latitude=self.latitude,
+                  array_height=self.array_height)
+
+        self.uu = uu
+        self.vv = vv
+        self.ww = ww
+
+        self.baselines_array = baselines_array
+        self.date_array = date_array
+
+        # self.assertTrue(os.path.isfile(self.output_uvfits_name))
+
+    def check_uvfits_contents(self, uvfits_name):
+
+        with fits.open(uvfits_name) as hdu:
+            ant_table = hdu[1]
+            data_table = hdu[0]
+
+            ##Some expected output values
+            annnames = np.array(['00001', '00002', '00003', '00004', '00005',
+                                 '00006', '00007', '00008', '00009', '00010'])
+
+            ##ant_table.data['ORBPARM'] is a weirdo empty array type that seems
+            ##to hang around in a uvfits file
+            ##At some point, the behaviour of astropy changes drastically so
+            ##this file gets read in as a totally different data type and shape
+            ##So based on what mood astropy is in, create an array to test against
+            ##SIIIIIIIIIIIIIIIIIGH
+
+            if ant_table.data['ORBPARM'].dtype == "float64":
+                nothing_array = np.array([], dtype='float64')
+                nothing_array.shape = (0,0)
+
+            else:
+                nothing_array = np.array([], dtype='|V8')
+                nothing_array.shape = (0,)
+
+            ##Test that a bunch of named columns in the antenna table are correct
+            self.assertTrue(np.array_equal(annnames, ant_table.data['ANNAME']))
+            self.assertTrue(np.array_equal(self.XYZ_array, ant_table.data['STABXYZ']))
+            self.assertTrue(np.array_equal(nothing_array, ant_table.data['ORBPARM']))
+            self.assertTrue(np.array_equal(np.arange(1, self.num_antennas+1), ant_table.data['NOSTA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['MNTSTA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['STAXOF']))
+            self.assertTrue(np.array_equal(np.array(['X']*self.num_antennas), ant_table.data['POLTYA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLAA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLCALA']))
+            self.assertTrue(np.array_equal(np.array(['Y']*self.num_antennas), ant_table.data['POLTYB']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLAB']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLCALB']))
+            ##Check the header of the antenna table
+            self.assertAlmostEqual(ant_table.header['ARRAYX'], -2559453.6265158253)
+            self.assertAlmostEqual(ant_table.header['ARRAYY'], 5095371.541942583)
+            self.assertAlmostEqual(ant_table.header['ARRAYZ'], -2849056.817561836)
+            self.assertEqual(ant_table.header['FREQ'], self.freq_cent)
+            self.assertAlmostEqual(ant_table.header['GSTIA0'], self.gst0_deg, delta=1e-9)
+            self.assertAlmostEqual(ant_table.header['DEGPDY'], self.degpdy, delta=1e-9)
+            self.assertAlmostEqual(ant_table.header['UT1UTC'], self.ut1utc, delta=1e-9)
+            self.assertEqual(ant_table.header['XYZHAND'], 'RIGHT')
+            self.assertEqual(ant_table.header['FRAME'], '????')
+            self.assertEqual(ant_table.header['RDATE'], self.date)
+            self.assertEqual(ant_table.header['TIMSYS'], 'UTC')
+            self.assertEqual(ant_table.header['ARRNAM'], self.telescope_name )
+            self.assertEqual(ant_table.header['NUMORB'], 0)
+            self.assertEqual(ant_table.header['NOPCAL'], 0)
+            self.assertEqual(ant_table.header['POLTYPE'], '')
+            self.assertEqual(ant_table.header['CREATOR'], 'WODEN_uvfits_writer')
+
+            ##Test that a bunch of named columns in the data table are correct
+            self.assertTrue(np.array_equal(self.uu, data_table.data['UU']))
+            self.assertTrue(np.array_equal(self.vv, data_table.data['VV']))
+            self.assertTrue(np.array_equal(self.ww, data_table.data['WW']))
+            self.assertTrue(np.array_equal(self.baselines_array, data_table.data['BASELINE']))
+            ##Astropy automatically adds the header value to the DATE array,
+            ##so need to subtract before comparison
+            self.assertTrue(np.array_equal(self.date_array, data_table.data['DATE']) - data_table.header['PZERO4'])
+
+
+            v_container = np.ones((self.num_time_steps*self.num_baselines, 1, 1, self.num_freq_channels, 4, 3))
+
+            ##Should get double values
+            v_container[:,0,0,:,:,:2] *= 2
+
+            ##Check the actual visisbility values are correct
+            self.assertTrue(np.allclose(v_container, data_table.data.data))
+
+            ##Check the header of the data table
+            self.assertEqual('COMPLEX', data_table.header['CTYPE2'])
+            self.assertEqual(1.0, data_table.header['CRVAL2'])
+            self.assertEqual(1.0, data_table.header['CRPIX2'])
+            self.assertEqual(1.0, data_table.header['CDELT2'])
+            self.assertEqual('STOKES', data_table.header['CTYPE3'])
+            self.assertEqual(-5.0, data_table.header['CRVAL3'])
+            self.assertEqual( 1.0, data_table.header['CRPIX3'])
+            self.assertEqual(-1.0, data_table.header['CDELT3'])
+            self.assertEqual('FREQ', data_table.header['CTYPE4'])
+            self.assertEqual(self.freq_cent, data_table.header['CRVAL4'])
+            self.assertEqual(int(self.central_freq_chan) + 1, data_table.header['CRPIX4'])
+            self.assertEqual(self.ch_width, data_table.header['CDELT4'])
+            self.assertEqual('RA', data_table.header['CTYPE5'])
+            self.assertEqual(self.ra_point, data_table.header['CRVAL5'])
+            self.assertEqual(1.0, data_table.header['CRPIX5'])
+            self.assertEqual(1.0, data_table.header['CDELT5'])
+            self.assertEqual('DEC', data_table.header['CTYPE6'])
+            self.assertEqual(self.dec_point, data_table.header['CRVAL6'])
+            self.assertEqual(1.0, data_table.header['CRPIX6'])
+            self.assertEqual(1.0, data_table.header['CDELT6'])
+            self.assertEqual(1.0, data_table.header['PSCAL1'])
+            self.assertEqual(0.0, data_table.header['PZERO1'])
+            self.assertEqual(1.0, data_table.header['PSCAL2'])
+            self.assertEqual(0.0, data_table.header['PZERO2'])
+            self.assertEqual(1.0, data_table.header['PSCAL3'])
+            self.assertEqual(0.0, data_table.header['PZERO3'])
+            self.assertEqual(1.0, data_table.header['PSCAL4'])
+            ##This is the date array so has an offset for JD date
+            self.assertEqual(float(self.int_jd), data_table.header['PZERO4'])
+            self.assertEqual(1.0, data_table.header['PSCAL5'])
+            self.assertEqual(0.0, data_table.header['PZERO5'])
+
+            self.assertEqual('Undefined', data_table.header['OBJECT'])
+            self.assertEqual(self.ra_point, data_table.header['OBSRA'])
+            self.assertEqual(self.dec_point, data_table.header['OBSDEC'])
+            self.assertEqual(self.gitlabel, data_table.header['GITLABEL'])
+
+            self.assertEqual(data_table.header['TELESCOP'], self.telescope_name)
+            self.assertEqual(data_table.header['LAT'], self.latitude)
+            self.assertEqual(data_table.header['LON'], self.longitude)
+            self.assertEqual(data_table.header['ALT'], self.array_height)
+            self.assertEqual(data_table.header['INSTRUME'], self.telescope_name)
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=2,
+                            uvfits_prepend1="unittest_example1_band",
+                            uvfits_prepend2="unittest_example2_band",
+                            uvfits1=False, uvfits2=False,
+                            output_name_prepend="combined_uvfits_band"))
+
+    def test_add_two_coarse_bands(self, mock_args):
+        """Checks that adding uvfits files that have `band{band}.uvfits`
+        at the end works, for two pairs of uvfits files (these are
+        created)"""
+
+        ##Some input test params
+        self.make_dummy_intputs()
+        self.create_uvfits_outputs()
+
+        self.output_uvfits_name = "unittest_example2_band01.uvfits"
+        self.create_uvfits_outputs()
+
+        self.output_uvfits_name = "unittest_example1_band02.uvfits"
+        self.create_uvfits_outputs()
+
+        self.output_uvfits_name = "unittest_example2_band02.uvfits"
+        self.create_uvfits_outputs()
+
+        awu.main()
+
+        self.check_uvfits_contents("combined_uvfits_band01.uvfits")
+        self.check_uvfits_contents("combined_uvfits_band02.uvfits")
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=1,
+                            uvfits_prepend1=False,
+                            uvfits_prepend2=False,
+                            uvfits1="unittest_example1_band01.uvfits",
+                            uvfits2="unittest_example2_band01.uvfits",
+                            output_name="combined_uvfits.uvfits"))
+
+    def test_add_two_files(self, mock_args):
+        """Checks that just adding to specified uvfits works"""
+
+        ##Some input test params
+        self.make_dummy_intputs()
+        self.create_uvfits_outputs()
+
+        self.output_uvfits_name = "unittest_example2_band01.uvfits"
+
+        self.create_uvfits_outputs()
+
+        awu.main()
+
+        self.check_uvfits_contents("combined_uvfits.uvfits")
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=1,
+                            uvfits_prepend1=False,
+                            uvfits_prepend2=False,
+                            uvfits1=False,
+                            uvfits2=False))
+
+    def test_no_file_strings_fails(self, mock_args):
+        """Check everything fails when you don't supply any strings to
+        a set of uvfits"""
+
+        ##Contain things when they go wrong
+        with self.assertRaises(SystemExit) as cm:
+            ##This call to main should die
+            awu.main()
+
+        expec_fail_string = "You must set either a combination "\
+             "of --uvfits_prepend1 and "\
+             "--uvfits_prepend2 or --uvfits1 and --uvfits2 otherwise I don't "\
+             "know what to sum"
+
+        self.assertEqual(cm.exception.code, expec_fail_string)
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=1,
+                            uvfits_prepend1="herego",
+                            uvfits_prepend2=False,
+                            uvfits1=False,
+                            uvfits2=False))
+
+    def test_no_uvfitsprep2_fails(self, mock_args):
+        """Check everything fails when you supply --uvfits_prepend1 but
+        not --uvfits_prepend2"""
+
+        ##Contain things when they go wrong
+        with self.assertRaises(SystemExit) as cm:
+            ##This call to main should die
+            awu.main()
+
+        expec_fail_string = "If you supply --uvfits_prepend1 you must supply --uvfits_prepend2"
+        self.assertEqual(cm.exception.code, expec_fail_string)
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=1,
+                            uvfits_prepend1=False,
+                            uvfits_prepend2="herego",
+                            uvfits1=False,
+                            uvfits2=False))
+
+    def test_no_uvfitsprep1_fails(self, mock_args):
+        """Check everything fails when you supply --uvfits_prepend2 but
+        not --uvfits_prepend1"""
+
+        ##Contain things when they go wrong
+        with self.assertRaises(SystemExit) as cm:
+            ##This call to main should die
+            awu.main()
+
+        expec_fail_string = "If you supply --uvfits_prepend2 you must supply --uvfits_prepend1"
+        self.assertEqual(cm.exception.code, expec_fail_string)
+
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=1,
+                            uvfits_prepend1=False,
+                            uvfits_prepend2=False,
+                            uvfits1="herego",
+                            uvfits2=False))
+
+    def test_no_uvfits2_fails(self, mock_args):
+        """Check everything fails when you supply --uvfits1 but
+        not --uvfits2"""
+
+        ##Contain things when they go wrong
+        with self.assertRaises(SystemExit) as cm:
+            ##This call to main should die
+            awu.main()
+
+        expec_fail_string = "If you supply --uvfits1 you must supply --uvfits2"
+        self.assertEqual(cm.exception.code, expec_fail_string)
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=1,
+                            uvfits_prepend1=False,
+                            uvfits_prepend2=False,
+                            uvfits1=False,
+                            uvfits2="herego"))
+
+    def test_no_uvfits1_fails(self, mock_args):
+        """Check everything fails when you supply --uvfits2 but
+        not --uvfits1"""
+
+        ##Contain things when they go wrong
+        with self.assertRaises(SystemExit) as cm:
+            ##This call to main should die
+            awu.main()
+
+        expec_fail_string = "If you supply --uvfits2 you must supply --uvfits1"
+        self.assertEqual(cm.exception.code, expec_fail_string)
+
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(uvfits_prepend1=False,
+                            uvfits_prepend2=False,
+                            uvfits1="unittest_example1_band01.uvfits",
+                            uvfits2="unittest_diff_dimension.uvfits",
+                            output_name=False))
+
+    def test_mismatch_data_fails(self, mock_args):
+        """Check everything fails when the dimensions of data in uvfits1
+        and uvfits2 do not match"""
+
+        self.make_dummy_intputs()
+        self.output_uvfits_name = "unittest_diff_dimension.uvfits"
+        self.create_uvfits_outputs(num_freqs=2)
+
+        ##Contain things when they go wrong
+        with self.assertRaises(SystemExit) as cm:
+            ##This call to main should die
+            awu.main()
+
+        expec_fail_string = "Shape of the data in the uvfits are not the same. Data "\
+             "might have different number of times steps, frequencies, "\
+             "or baselines."
+        self.assertEqual(cm.exception.code, expec_fail_string)
+
+##Run the test
+if __name__ == '__main__':
+   unittest.main()

--- a/cmake_testing/array_layout/test_calc_XYZ_diffs.c
+++ b/cmake_testing/array_layout/test_calc_XYZ_diffs.c
@@ -18,7 +18,7 @@ calculates the baseline length in X,Y,Z
 Test by reading in a known set of e,n,h and a given example julian date, and
 make sure outputs match expectations
 */
-void test_calc_XYZ_diffs_GivesCorrectValues(int do_precession)
+void test_calc_XYZ_diffs_GivesCorrectValues(int do_precession, int do_autos)
 {
 
   woden_settings_t *woden_settings = malloc(sizeof(woden_settings_t));
@@ -43,6 +43,9 @@ void test_calc_XYZ_diffs_GivesCorrectValues(int do_precession)
   woden_settings->lsts = lsts;
   woden_settings->time_res = 8;
   woden_settings->mjds = mjds;
+  woden_settings->num_freqs = 3;
+
+  woden_settings->do_autos = do_autos;
 
   //Call the function we are testing
   array_layout_t * array_layout;
@@ -51,6 +54,22 @@ void test_calc_XYZ_diffs_GivesCorrectValues(int do_precession)
   //Test some basic quantities
   TEST_ASSERT_EQUAL_INT(28, array_layout->num_baselines);
   TEST_ASSERT_EQUAL_INT(8, array_layout->num_tiles);
+
+  int expec_num_visi, expec_num_cross, expec_num_auto;
+
+  expec_num_cross = woden_settings->num_time_steps*array_layout->num_baselines*woden_settings->num_freqs;
+
+  if (do_autos) {
+    expec_num_auto = woden_settings->num_time_steps*array_layout->num_tiles*woden_settings->num_freqs;
+  } else {
+    expec_num_auto = 0;
+  }
+
+  expec_num_visi = expec_num_auto + expec_num_cross;
+
+  TEST_ASSERT_EQUAL_INT(expec_num_visi, woden_settings->num_visis);
+  TEST_ASSERT_EQUAL_INT(expec_num_cross, woden_settings->num_cross);
+  TEST_ASSERT_EQUAL_INT(expec_num_auto, woden_settings->num_autos);
 
   //These are the values in "example_array_layout.txt"
   double expec_east[] = {84., 12., 86., 780., 813., 899., 460., 810.};
@@ -123,22 +142,26 @@ void test_calc_XYZ_diffs_GivesCorrectValues(int do_precession)
   }
 }
 
-void test_calc_XYZ_diffs_GivesCorrectValuesNoPrecess(void)
+void test_calc_XYZ_diffs_GivesCorrectValuesNoPrecessNoAutos(void)
 {
-  test_calc_XYZ_diffs_GivesCorrectValues(0);
+  int do_precession = 0;
+  int do_autos = 0;
+  test_calc_XYZ_diffs_GivesCorrectValues(do_precession, do_autos);
 }
 
-void test_calc_XYZ_diffs_GivesCorrectValuesPrecess(void)
+void test_calc_XYZ_diffs_GivesCorrectValuesPrecessNoAutos(void)
 {
-  test_calc_XYZ_diffs_GivesCorrectValues(1);
+  int do_precession = 1;
+  int do_autos = 0;
+  test_calc_XYZ_diffs_GivesCorrectValues(do_precession, do_autos);
 }
 //Run test using unity
 int main(void)
 {
     UNITY_BEGIN();
 
-    RUN_TEST(test_calc_XYZ_diffs_GivesCorrectValuesNoPrecess);
-    RUN_TEST(test_calc_XYZ_diffs_GivesCorrectValuesPrecess);
+    RUN_TEST(test_calc_XYZ_diffs_GivesCorrectValuesNoPrecessNoAutos);
+    RUN_TEST(test_calc_XYZ_diffs_GivesCorrectValuesPrecessNoAutos);
 
     return UNITY_END();
 }

--- a/cmake_testing/calculate_visibilities/test_calculate_visibilities_common.h
+++ b/cmake_testing/calculate_visibilities/test_calculate_visibilities_common.h
@@ -14,10 +14,12 @@
 #include "hdf5.h"
 #include "hdf5_hl.h"
 
+#define NUM_ANTS 3
 #define NUM_BASELINES 3
 #define NUM_FREQS 3
 #define NUM_TIME_STEPS 2
-#define NUM_VISI NUM_BASELINES*NUM_FREQS*NUM_TIME_STEPS
+#define NUM_CROSS NUM_BASELINES*NUM_FREQS*NUM_TIME_STEPS
+#define NUM_VISI NUM_CROSS
 #define RA0 0.0
 #define BASE_BAND_FREQ 120000000.0
 #define STOKESI 0.3333333333333333
@@ -39,7 +41,7 @@ void free_sky_model(source_catalogue_t *cropped_sky_models);
 woden_settings_t * make_woden_settings(double ra0, double dec0);
 
 void test_uvw(visibility_set_t *visibility_set,  double *lsts,
-              double ra0, double dec0);
+              double ra0, double dec0, woden_settings_t *woden_settings);
 
 visibility_set_t * test_calculate_visibilities(source_catalogue_t *cropped_sky_models,
                                  beam_settings_t *beam_settings,
@@ -49,4 +51,17 @@ visibility_set_t * test_calculate_visibilities(source_catalogue_t *cropped_sky_m
 
 void test_comp_phase_centre_twogains(visibility_set_t *visibility_set,
                                      double gain1xx, double gain1yy,
-                                     double gain2xx, double gain2yy);
+                                     double gain2xx, double gain2yy,
+                                     woden_settings_t *woden_settings);
+
+void test_comp_phase_centre_allgains(visibility_set_t *visibility_set,
+                                     double gain1xx_re, double gain1xx_im,
+                                     double gain1xy_re, double gain1xy_im,
+                                     double gain1yx_re, double gain1yx_im,
+                                     double gain1yy_re, double gain1yy_im,
+                                     double gain2xx_re, double gain2xx_im,
+                                     double gain2xy_re, double gain2xy_im,
+                                     double gain2yx_re, double gain2yx_im,
+                                     double gain2yy_re, double gain2yy_im,
+                                     woden_settings_t *woden_settings,
+                                     double tol);

--- a/cmake_testing/calculate_visibilities/test_calculate_visibilities_edabeam.c
+++ b/cmake_testing/calculate_visibilities/test_calculate_visibilities_edabeam.c
@@ -46,19 +46,28 @@ void test_calculate_visibilities_EDA2Beam(int n_points, int n_gauss, int n_shape
   double gain2yy = 0.3825515398230647 * (n_points + n_gauss + n_shapes)*num_sources*STOKESI;
   //
   test_comp_phase_centre_twogains(visibility_set, gain1xx, gain1yy,
-                                  gain2xx, gain2yy);
+                                  gain2xx, gain2yy, woden_settings);
 
-  // for (size_t visi = 0; visi < NUM_VISI; visi++) {
-  //   printf("%.7f %.1f %.1f %.1f %.1f %.1f %.7f %.1f\n",
-  //           visibility_set->sum_visi_XX_real[visi],
-  //           visibility_set->sum_visi_XX_imag[visi],
-  //           visibility_set->sum_visi_XY_real[visi],
-  //           visibility_set->sum_visi_XY_imag[visi],
-  //           visibility_set->sum_visi_YX_real[visi],
-  //           visibility_set->sum_visi_YX_imag[visi],
-  //           visibility_set->sum_visi_YY_real[visi],
-  //           visibility_set->sum_visi_YY_imag[visi]);
-  // }
+  free_visi_set_inputs(visibility_set);
+  free_visi_set_outputs(visibility_set);
+
+  woden_settings->do_autos = 1;
+  woden_settings->num_autos = NUM_CROSS;
+  woden_settings->num_visis = woden_settings->num_cross + woden_settings->num_autos;
+
+  cropped_sky_models = make_cropped_sky_models(RA0, MWA_LAT_RAD,
+                                                    n_points, n_gauss, n_shapes,
+                                                    num_sources);
+
+  printf("We have this many visis %d %d %d\n",woden_settings->num_visis,woden_settings->num_autos,woden_settings->num_cross );
+  visibility_set = test_calculate_visibilities(cropped_sky_models,
+                                          beam_settings, woden_settings, RA0, MWA_LAT_RAD,
+                                          beam_settings->beamtype);
+  test_comp_phase_centre_twogains(visibility_set, gain1xx, gain1yy,
+                                  gain2xx, gain2yy, woden_settings);
+
+  free_visi_set_inputs(visibility_set);
+  free_visi_set_outputs(visibility_set);
 
 }
 

--- a/cmake_testing/calculate_visibilities/test_calculate_visibilities_gaussbeam.c
+++ b/cmake_testing/calculate_visibilities/test_calculate_visibilities_gaussbeam.c
@@ -52,19 +52,31 @@ void test_calculate_visibilities_GaussBeam(int n_points, int n_gauss, int n_shap
   double gain1 = 0.9702956182744840 * (n_points + n_gauss + n_shapes)*num_sources*STOKESI;
   double gain2 = 0.3359480937784178 * (n_points + n_gauss + n_shapes)*num_sources*STOKESI;
 
-  test_comp_phase_centre_twogains(visibility_set, gain1, gain1, gain2, gain2);
+  test_comp_phase_centre_twogains(visibility_set, gain1, gain1, gain2, gain2,
+                                                                woden_settings);
 
-  // for (size_t visi = 0; visi < NUM_VISI; visi++) {
-  //   printf("%.6f %.1f %.1f %.1f %.1f %.1f %.6f %.1f\n",
-  //           visibility_set->sum_visi_XX_real[visi],
-  //           visibility_set->sum_visi_XX_imag[visi],
-  //           visibility_set->sum_visi_XY_real[visi],
-  //           visibility_set->sum_visi_XY_imag[visi],
-  //           visibility_set->sum_visi_YX_real[visi],
-  //           visibility_set->sum_visi_YX_imag[visi],
-  //           visibility_set->sum_visi_YY_real[visi],
-  //           visibility_set->sum_visi_YY_imag[visi]);
-  // }
+  free_visi_set_inputs(visibility_set);
+  free_visi_set_outputs(visibility_set);
+
+  woden_settings->do_autos = 1;
+  woden_settings->num_autos = NUM_CROSS;
+  woden_settings->num_visis = woden_settings->num_cross + woden_settings->num_autos;
+
+  cropped_sky_models = make_cropped_sky_models(RA0, MWA_LAT_RAD,
+                                                    n_points, n_gauss, n_shapes,
+                                                    num_sources);
+
+  printf("We have this many visis %d %d %d\n",woden_settings->num_visis,woden_settings->num_autos,woden_settings->num_cross );
+  visibility_set = test_calculate_visibilities(cropped_sky_models,
+                                          beam_settings, woden_settings, RA0, MWA_LAT_RAD,
+                                          beam_settings->beamtype);
+  test_comp_phase_centre_twogains(visibility_set, gain1, gain1, gain2, gain2,
+                                                                woden_settings);
+
+  free_visi_set_inputs(visibility_set);
+  free_visi_set_outputs(visibility_set);
+
+
 
 }
 

--- a/cmake_testing/calculate_visibilities/test_calculate_visibilities_mwafeebeam.c
+++ b/cmake_testing/calculate_visibilities/test_calculate_visibilities_mwafeebeam.c
@@ -26,67 +26,6 @@ extern void calculate_visibilities(array_layout_t *array_layout,
 void setUp (void) {} /* Is run before every test, put unit init calls here. */
 void tearDown (void) {} /* Is run after every test, put unit clean-up calls here. */
 
-void test_comp_phase_centre_allgains(visibility_set_t *visibility_set,
-                                     double gain1xx_re, double gain1xx_im,
-                                     double gain1xy_re, double gain1xy_im,
-                                     double gain1yx_re, double gain1yx_im,
-                                     double gain1yy_re, double gain1yy_im,
-                                     double gain2xx_re, double gain2xx_im,
-                                     double gain2xy_re, double gain2xy_im,
-                                     double gain2yx_re, double gain2yx_im,
-                                     double gain2yy_re, double gain2yy_im) {
-
-  //Small user_precision_t errors in the measurement equation mean that when at phase
-  //centre, altough imaginary should be zero, you get fluctuations dependent
-  //on u,v,w. So need a different tolerance here
-  //The accuracy we get depends on whether we are float or double
-  #ifdef DOUBLE_PRECISION
-    double TOL = 1e-9;
-  #else
-    double TOL = 1e-5;
-
-  #endif
-
-  for (int visi = 0; visi < NUM_VISI; visi++) {
-    if (visi < NUM_VISI / 2) {
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xx_re,
-                                        visibility_set->sum_visi_XX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xx_im,
-                                        visibility_set->sum_visi_XX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xy_re,
-                                        visibility_set->sum_visi_XY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xy_im,
-                                        visibility_set->sum_visi_XY_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yx_re,
-                                        visibility_set->sum_visi_YX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yx_im,
-                                        visibility_set->sum_visi_YX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yy_re,
-                                        visibility_set->sum_visi_YY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yy_im,
-                                        visibility_set->sum_visi_YY_imag[visi]);
-    }
-    else {
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xx_re,
-                                        visibility_set->sum_visi_XX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xx_im,
-                                        visibility_set->sum_visi_XX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xy_re,
-                                        visibility_set->sum_visi_XY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xy_im,
-                                        visibility_set->sum_visi_XY_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yx_re,
-                                        visibility_set->sum_visi_YX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yx_im,
-                                        visibility_set->sum_visi_YX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yy_re,
-                                        visibility_set->sum_visi_YY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yy_im,
-                                        visibility_set->sum_visi_YY_imag[visi]);
-    }
-  }
-}
-
 void test_calculate_visibilities_MWAFEEBeam(int n_points, int n_gauss, int n_shapes,
                                            int num_sources) {
 
@@ -108,23 +47,7 @@ void test_calculate_visibilities_MWAFEEBeam(int n_points, int n_gauss, int n_sha
                                           beam_settings, woden_settings, RA0, MWA_LAT_RAD,
                                           beam_settings->beamtype);
 
-  printf("WODEN settings %d %d %d\n",woden_settings->num_time_steps,
-                                     woden_settings->num_freqs,
-                                     woden_settings->num_baselines );
-  // for (size_t visi = 0; visi < NUM_VISI; visi++) {
-  //   printf("%.8f %.8f %.8f %.8f %.8f %.8f %.8f %.8f\n",
-  //           visibility_set->sum_visi_XX_real[visi],
-  //           visibility_set->sum_visi_XX_imag[visi],
-  //           visibility_set->sum_visi_XY_real[visi],
-  //           visibility_set->sum_visi_XY_imag[visi],
-  //           visibility_set->sum_visi_YX_real[visi],
-  //           visibility_set->sum_visi_YX_imag[visi],
-  //           visibility_set->sum_visi_YY_real[visi],
-  //           visibility_set->sum_visi_YY_imag[visi]);
-  // }
-
   double multiplier = (n_points + n_gauss + n_shapes)*num_sources*STOKESI;
-
 
   //These values are taken from the double precision version of the MWA FEE
   //beam code
@@ -146,6 +69,17 @@ void test_calculate_visibilities_MWAFEEBeam(int n_points, int n_gauss, int n_sha
   double gain2yy_re = 0.0038896732780955* multiplier;
   double gain2yy_im = 0.0 * multiplier;
 
+  //Small user_precision_t errors in the measurement equation mean that when at phase
+  //centre, altough imaginary should be zero, you get fluctuations dependent
+  //on u,v,w. So need a different tolerance here
+  //The accuracy we get depends on whether we are float or double
+  #ifdef DOUBLE_PRECISION
+    double TOL = 1e-9;
+  #else
+    double TOL = 1e-5;
+
+  #endif
+
   test_comp_phase_centre_allgains(visibility_set,
                                   gain1xx_re, gain1xx_im,
                                   gain1xy_re, gain1xy_im,
@@ -154,11 +88,36 @@ void test_calculate_visibilities_MWAFEEBeam(int n_points, int n_gauss, int n_sha
                                   gain2xx_re, gain2xx_im,
                                   gain2xy_re, gain2xy_im,
                                   gain2yx_re, gain2yx_im,
-                                  gain2yy_re, gain2yy_im);
+                                  gain2yy_re, gain2yy_im,
+                                  woden_settings, TOL);
 
+  free_visi_set_inputs(visibility_set);
+  free_visi_set_outputs(visibility_set);
+
+  woden_settings->do_autos = 1;
+  woden_settings->num_autos = NUM_CROSS;
+  woden_settings->num_visis = woden_settings->num_cross + woden_settings->num_autos;
+
+  cropped_sky_models = make_cropped_sky_models(RA0, MWA_LAT_RAD,
+                                                    n_points, n_gauss, n_shapes,
+                                                    num_sources);
+
+  printf("We have this many visis %d %d %d\n",woden_settings->num_visis,woden_settings->num_autos,woden_settings->num_cross );
+  visibility_set = test_calculate_visibilities(cropped_sky_models,
+                                          beam_settings, woden_settings, RA0, MWA_LAT_RAD,
+                                          beam_settings->beamtype);
+  test_comp_phase_centre_allgains(visibility_set,
+                                  gain1xx_re, gain1xx_im,
+                                  gain1xy_re, gain1xy_im,
+                                  gain1yx_re, gain1yx_im,
+                                  gain1yy_re, gain1yy_im,
+                                  gain2xx_re, gain2xx_im,
+                                  gain2xy_re, gain2xy_im,
+                                  gain2yx_re, gain2yx_im,
+                                  gain2yy_re, gain2yy_im,
+                                  woden_settings, TOL);
 
   free_fee_beam(beam_settings->fee_beam);
-
   free(beam_settings);
   free_visi_set_inputs(visibility_set);
   free_visi_set_outputs(visibility_set);

--- a/cmake_testing/calculate_visibilities/test_calculate_visibilities_mwafeebeaminterp.c
+++ b/cmake_testing/calculate_visibilities/test_calculate_visibilities_mwafeebeaminterp.c
@@ -26,66 +26,6 @@ extern void calculate_visibilities(array_layout_t *array_layout,
 void setUp (void) {} /* Is run before every test, put unit init calls here. */
 void tearDown (void) {} /* Is run after every test, put unit clean-up calls here. */
 
-void test_comp_phase_centre_allgains(visibility_set_t *visibility_set,
-                                     double gain1xx_re, double gain1xx_im,
-                                     double gain1xy_re, double gain1xy_im,
-                                     double gain1yx_re, double gain1yx_im,
-                                     double gain1yy_re, double gain1yy_im,
-                                     double gain2xx_re, double gain2xx_im,
-                                     double gain2xy_re, double gain2xy_im,
-                                     double gain2yx_re, double gain2yx_im,
-                                     double gain2yy_re, double gain2yy_im) {
-
-  //Small user_precision_t errors in the measurement equation mean that when at phase
-  //centre, altough imaginary should be zero, you get fluctuations dependent
-  //on u,v,w. So need a different tolerance here
-  //The accuracy we get depends on whether we are float or double
-  #ifdef DOUBLE_PRECISION
-    double TOL = 1e-7;
-  #else
-    double TOL = 3e-2;
-  #endif
-
-  for (int visi = 0; visi < NUM_VISI; visi++) {
-    if (visi < NUM_VISI / 2) {
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xx_re,
-                                        visibility_set->sum_visi_XX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xx_im,
-                                        visibility_set->sum_visi_XX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xy_re,
-                                        visibility_set->sum_visi_XY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1xy_im,
-                                        visibility_set->sum_visi_XY_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yx_re,
-                                        visibility_set->sum_visi_YX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yx_im,
-                                        visibility_set->sum_visi_YX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yy_re,
-                                        visibility_set->sum_visi_YY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain1yy_im,
-                                        visibility_set->sum_visi_YY_imag[visi]);
-    }
-    else {
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xx_re,
-                                        visibility_set->sum_visi_XX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xx_im,
-                                        visibility_set->sum_visi_XX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xy_re,
-                                        visibility_set->sum_visi_XY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2xy_im,
-                                        visibility_set->sum_visi_XY_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yx_re,
-                                        visibility_set->sum_visi_YX_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yx_im,
-                                        visibility_set->sum_visi_YX_imag[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yy_re,
-                                        visibility_set->sum_visi_YY_real[visi]);
-      TEST_ASSERT_DOUBLE_WITHIN(TOL, gain2yy_im,
-                                        visibility_set->sum_visi_YY_imag[visi]);
-    }
-  }
-}
-
 void test_calculate_visibilities_MWAFEEBeamInterp(int n_points, int n_gauss, int n_shapes,
                                            int num_sources) {
 
@@ -144,6 +84,12 @@ void test_calculate_visibilities_MWAFEEBeamInterp(int n_points, int n_gauss, int
   double gain2yy_re = 0.020706076999 * multiplier;
   double gain2yy_im = 0.0 * multiplier;
 
+  #ifdef DOUBLE_PRECISION
+    double TOL = 1e-7;
+  #else
+    double TOL = 3e-2;
+  #endif
+
   test_comp_phase_centre_allgains(visibility_set,
                                   gain1xx_re, gain1xx_im,
                                   gain1xy_re, gain1xy_im,
@@ -152,13 +98,40 @@ void test_calculate_visibilities_MWAFEEBeamInterp(int n_points, int n_gauss, int
                                   gain2xx_re, gain2xx_im,
                                   gain2xy_re, gain2xy_im,
                                   gain2yx_re, gain2yx_im,
-                                  gain2yy_re, gain2yy_im);
+                                  gain2yy_re, gain2yy_im,
+                                  woden_settings, TOL);
+
+  free_visi_set_inputs(visibility_set);
+  free_visi_set_outputs(visibility_set);
+
+  woden_settings->do_autos = 1;
+  woden_settings->num_autos = NUM_CROSS;
+  woden_settings->num_visis = woden_settings->num_cross + woden_settings->num_autos;
+
+  cropped_sky_models = make_cropped_sky_models(RA0, MWA_LAT_RAD,
+                                                    n_points, n_gauss, n_shapes,
+                                                    num_sources);
+
+  printf("We have this many visis %d %d %d\n",woden_settings->num_visis,woden_settings->num_autos,woden_settings->num_cross );
+  visibility_set = test_calculate_visibilities(cropped_sky_models,
+                                          beam_settings, woden_settings, RA0, MWA_LAT_RAD,
+                                          beam_settings->beamtype);
+  test_comp_phase_centre_allgains(visibility_set,
+                                  gain1xx_re, gain1xx_im,
+                                  gain1xy_re, gain1xy_im,
+                                  gain1yx_re, gain1yx_im,
+                                  gain1yy_re, gain1yy_im,
+                                  gain2xx_re, gain2xx_im,
+                                  gain2xy_re, gain2xy_im,
+                                  gain2yx_re, gain2yx_im,
+                                  gain2yy_re, gain2yy_im,
+                                  woden_settings, TOL);
 
   free_fee_beam(beam_settings->fee_beam);
   free(beam_settings);
-  free(woden_settings);
   free_visi_set_inputs(visibility_set);
   free_visi_set_outputs(visibility_set);
+  free(woden_settings);
 }
 
 //Test with a single SOURCE, single COMPONENT

--- a/cmake_testing/concat_woden_uvfits/CMakeLists.txt
+++ b/cmake_testing/concat_woden_uvfits/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+include(FindPythonInterp)
+
+##Set an environment variable for the ctest of this, so we can find a path
+##to some test files that live in this dir
+add_test(python_test_concat_woden_uvfits ${PYTHON_EXECUTABLE}
+${CMAKE_CURRENT_SOURCE_DIR}/test_concat_woden_uvfits.py)
+set_tests_properties(python_test_concat_woden_uvfits PROPERTIES
+         ENVIRONMENT CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR})

--- a/cmake_testing/concat_woden_uvfits/test_concat_woden_uvfits.py
+++ b/cmake_testing/concat_woden_uvfits/test_concat_woden_uvfits.py
@@ -1,0 +1,267 @@
+from sys import path
+import os
+import unittest
+import numpy as np
+from astropy.io import fits
+from unittest import mock
+import argparse
+
+##This is where our code lives
+code_dir = os.environ['CMAKE_CURRENT_SOURCE_DIR']
+
+##Append the location of run_woden.py to the sys.path to import it
+path.append('{:s}/../../src'.format(code_dir))
+
+##Code we are testing
+import run_woden as rw
+import concat_woden_uvfits as cwu
+
+##Vehicle for running tests
+class Test(unittest.TestCase):
+    def make_dummy_intputs(self):
+        """Makes some inputs used to pass to rw.create_uvfits"""
+        self.date = "2019-06-12T13:04:12"
+        self.gst0_deg = 260.0303917560829
+        self.degpdy = 360.98563614850775
+        self.ut1utc = -0.17421478816666666
+        self.num_antennas = 10
+        self.freq_cent = 160e+6
+        self.telescope_name = "MWA"
+        self.longitude = 116.670813889
+        self.latitude = -26.7033194444
+        self.array_height = 377.0
+        self.central_freq_chan = 2
+        self.ch_width = 40e3
+        self.ra_point = 0.0
+        self.dec_point = -26.7
+        self.num_baselines = int(((self.num_antennas - 1)*self.num_antennas) / 2)
+        self.num_time_steps = 2
+        self.num_freq_channels = 3
+        self.int_jd = 2458647.0
+        self.gitlabel = 'as987has'
+        self.XYZ_array = np.arange(self.num_antennas*3)
+        self.XYZ_array.shape = (self.num_antennas, 3)
+        self.output_uvfits_name = "unittest_example1_band01.uvfits"
+
+    def create_uvfits_outputs(self, visi_values=1, num_freqs=3):
+        """Tests the `rw.create_uvfits` function, which should take a whole
+        heap of inputs and write out a uvits. Test by running funciton,
+        reading in the created file and checking contents"""
+
+        self.num_freq_channels = num_freqs
+
+        ##Create an antenna table
+        ant_table = rw.make_antenna_table(XYZ_array=self.XYZ_array,
+                      telescope_name=self.telescope_name,
+                      num_antennas=self.num_antennas, freq_cent=self.freq_cent,
+                      date=self.date, gst0_deg=self.gst0_deg,
+                      degpdy=self.degpdy, ut1utc=self.ut1utc,
+                      longitude=self.longitude, latitude=self.latitude,
+                      array_height=self.array_height)
+
+        ##Create some dummy data inputs
+        v_container = np.ones((self.num_time_steps*self.num_baselines, 1, 1, self.num_freq_channels, 4, 3))*visi_values
+
+        uu = np.arange(self.num_baselines*self.num_time_steps)
+        vv = np.arange(self.num_baselines*self.num_time_steps) + self.num_baselines
+        ww = np.arange(self.num_baselines*self.num_time_steps) + 2*self.num_baselines
+        baselines_array = np.arange(self.num_baselines*self.num_time_steps)
+
+        date_array = np.ones(self.num_time_steps*self.num_baselines)*0.04458333319
+        ##Add a second of time onto the second half of the date array
+        date_array[self.num_baselines:] += (1 / (24.0*60.0*60.0))
+
+        rw.create_uvfits(freq_cent=self.freq_cent, ch_width=self.ch_width,
+                  central_freq_chan=self.central_freq_chan,
+                  ra_point=self.ra_point, dec_point=self.dec_point,
+                  output_uvfits_name=self.output_uvfits_name,
+                  int_jd=self.int_jd, gitlabel=self.gitlabel,
+                  v_container=v_container,
+                  uu=uu, vv=vv, ww=ww,
+                  baselines_array=baselines_array, date_array=date_array,
+                  hdu_ant=ant_table, telescope_name=self.telescope_name,
+                  longitude=self.longitude, latitude=self.latitude,
+                  array_height=self.array_height)
+
+        self.uu = uu
+        self.vv = vv
+        self.ww = ww
+
+        self.baselines_array = baselines_array
+        self.date_array = date_array
+
+    def check_uvfits_contents(self, uvfits_name, expec_data, expec_num_freqs):
+
+        with fits.open(uvfits_name) as hdu:
+            ant_table = hdu[1]
+            data_table = hdu[0]
+
+            ##Some expected output values
+            annnames = np.array(['00001', '00002', '00003', '00004', '00005',
+                                 '00006', '00007', '00008', '00009', '00010'])
+
+            ##ant_table.data['ORBPARM'] is a weirdo empty array type that seems
+            ##to hang around in a uvfits file
+            ##At some point, the behaviour of astropy changes drastically so
+            ##this file gets read in as a totally different data type and shape
+            ##So based on what mood astropy is in, create an array to test against
+            ##SIIIIIIIIIIIIIIIIIGH
+
+            if ant_table.data['ORBPARM'].dtype == "float64":
+                nothing_array = np.array([], dtype='float64')
+                nothing_array.shape = (0,0)
+
+            else:
+                nothing_array = np.array([], dtype='|V8')
+                nothing_array.shape = (0,)
+
+            ##Test that a bunch of named columns in the antenna table are correct
+            self.assertTrue(np.array_equal(annnames, ant_table.data['ANNAME']))
+            self.assertTrue(np.array_equal(self.XYZ_array, ant_table.data['STABXYZ']))
+            self.assertTrue(np.array_equal(nothing_array, ant_table.data['ORBPARM']))
+            self.assertTrue(np.array_equal(np.arange(1, self.num_antennas+1), ant_table.data['NOSTA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['MNTSTA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['STAXOF']))
+            self.assertTrue(np.array_equal(np.array(['X']*self.num_antennas), ant_table.data['POLTYA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLAA']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLCALA']))
+            self.assertTrue(np.array_equal(np.array(['Y']*self.num_antennas), ant_table.data['POLTYB']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLAB']))
+            self.assertTrue(np.array_equal(np.zeros(self.num_antennas), ant_table.data['POLCALB']))
+            ##Check the header of the antenna table
+            self.assertAlmostEqual(ant_table.header['ARRAYX'], -2559453.6265158253)
+            self.assertAlmostEqual(ant_table.header['ARRAYY'], 5095371.541942583)
+            self.assertAlmostEqual(ant_table.header['ARRAYZ'], -2849056.817561836)
+            self.assertEqual(ant_table.header['FREQ'], self.freq_cent)
+            self.assertAlmostEqual(ant_table.header['GSTIA0'], self.gst0_deg, delta=1e-9)
+            self.assertAlmostEqual(ant_table.header['DEGPDY'], self.degpdy, delta=1e-9)
+            self.assertAlmostEqual(ant_table.header['UT1UTC'], self.ut1utc, delta=1e-9)
+            self.assertEqual(ant_table.header['XYZHAND'], 'RIGHT')
+            self.assertEqual(ant_table.header['FRAME'], '????')
+            self.assertEqual(ant_table.header['RDATE'], self.date)
+            self.assertEqual(ant_table.header['TIMSYS'], 'UTC')
+            self.assertEqual(ant_table.header['ARRNAM'], self.telescope_name )
+            self.assertEqual(ant_table.header['NUMORB'], 0)
+            self.assertEqual(ant_table.header['NOPCAL'], 0)
+            self.assertEqual(ant_table.header['POLTYPE'], '')
+            self.assertEqual(ant_table.header['CREATOR'], 'WODEN_uvfits_writer')
+
+            ##Test that a bunch of named columns in the data table are correct
+            self.assertTrue(np.array_equal(self.uu, data_table.data['UU']))
+            self.assertTrue(np.array_equal(self.vv, data_table.data['VV']))
+            self.assertTrue(np.array_equal(self.ww, data_table.data['WW']))
+            self.assertTrue(np.array_equal(self.baselines_array, data_table.data['BASELINE']))
+            ##Astropy automatically adds the header value to the DATE array,
+            ##so need to subtract before comparison
+            self.assertTrue(np.array_equal(self.date_array, data_table.data['DATE']) - data_table.header['PZERO4'])
+
+            ##Check the actual visisbility values are correct
+            self.assertTrue(np.allclose(expec_data, data_table.data.data))
+
+            ##Check the header of the data table
+            self.assertEqual('COMPLEX', data_table.header['CTYPE2'])
+            self.assertEqual(1.0, data_table.header['CRVAL2'])
+            self.assertEqual(1.0, data_table.header['CRPIX2'])
+            self.assertEqual(1.0, data_table.header['CDELT2'])
+            self.assertEqual('STOKES', data_table.header['CTYPE3'])
+            self.assertEqual(-5.0, data_table.header['CRVAL3'])
+            self.assertEqual( 1.0, data_table.header['CRPIX3'])
+            self.assertEqual(-1.0, data_table.header['CDELT3'])
+            self.assertEqual('FREQ', data_table.header['CTYPE4'])
+            self.assertEqual(self.freq_cent, data_table.header['CRVAL4'])
+            self.assertEqual(int(self.central_freq_chan) + 1, data_table.header['CRPIX4'])
+            self.assertEqual(self.ch_width, data_table.header['CDELT4'])
+            self.assertEqual('RA', data_table.header['CTYPE5'])
+            self.assertEqual(self.ra_point, data_table.header['CRVAL5'])
+            self.assertEqual(1.0, data_table.header['CRPIX5'])
+            self.assertEqual(1.0, data_table.header['CDELT5'])
+            self.assertEqual('DEC', data_table.header['CTYPE6'])
+            self.assertEqual(self.dec_point, data_table.header['CRVAL6'])
+            self.assertEqual(1.0, data_table.header['CRPIX6'])
+            self.assertEqual(1.0, data_table.header['CDELT6'])
+            self.assertEqual(1.0, data_table.header['PSCAL1'])
+            self.assertEqual(0.0, data_table.header['PZERO1'])
+            self.assertEqual(1.0, data_table.header['PSCAL2'])
+            self.assertEqual(0.0, data_table.header['PZERO2'])
+            self.assertEqual(1.0, data_table.header['PSCAL3'])
+            self.assertEqual(0.0, data_table.header['PZERO3'])
+            self.assertEqual(1.0, data_table.header['PSCAL4'])
+            ##This is the date array so has an offset for JD date
+            self.assertEqual(float(self.int_jd), data_table.header['PZERO4'])
+            self.assertEqual(1.0, data_table.header['PSCAL5'])
+            self.assertEqual(0.0, data_table.header['PZERO5'])
+
+            self.assertEqual('Undefined', data_table.header['OBJECT'])
+            self.assertEqual(self.ra_point, data_table.header['OBSRA'])
+            self.assertEqual(self.dec_point, data_table.header['OBSDEC'])
+            self.assertEqual(self.gitlabel, data_table.header['GITLABEL'])
+
+            self.assertEqual(data_table.header['TELESCOP'], self.telescope_name)
+            self.assertEqual(data_table.header['LAT'], self.latitude)
+            self.assertEqual(data_table.header['LON'], self.longitude)
+            self.assertEqual(data_table.header['ALT'], self.array_height)
+            self.assertEqual(data_table.header['INSTRUME'], self.telescope_name)
+
+    ##Setup some fake command line things for the following test
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(num_bands=4,
+                            uvfits_prepend="unittest_example1_band",
+                            output_name="concatenated_uvfuts.uvfits"))
+
+    def test_concat_four_uvfits(self, mock_args):
+        """Checks that concatenating four uvfits files that have `band{band}.uvfits`
+        at the end works, by creating four uvfits with known properties"""
+
+        ##Some input test params
+        self.make_dummy_intputs()
+        self.create_uvfits_outputs()
+
+        expec_data = np.ones((self.num_time_steps*self.num_baselines, 1, 1, self.num_freq_channels*4, 4, 3))
+
+        for band in range(2,5):
+            cent_freq = self.freq_cent
+
+            self.freq_cent += self.num_freq_channels*self.ch_width
+
+            self.output_uvfits_name = f"unittest_example1_band{band:02d}.uvfits"
+            self.create_uvfits_outputs(visi_values=band)
+
+            low = self.num_freq_channels*(band - 1)
+            high = self.num_freq_channels*band
+
+            expec_data[:, 0, 0, low:high, :, :] = band
+
+        cwu.main()
+
+        ##Stick the frequencies settings to the first uvfits
+        self.freq_cent = 160e+6
+        self.check_uvfits_contents("concatenated_uvfuts.uvfits",
+                              expec_data,
+                              self.num_freq_channels*4)
+
+        #
+        # self.check_uvfits_contents("combined_uvfits_band01.uvfits")
+        # self.check_uvfits_contents("combined_uvfits_band02.uvfits")
+
+
+    # def test_mismatch_data_fails(self, mock_args):
+    #     """Check everything fails when the dimensions of data in uvfits1
+    #     and uvfits2 do not match"""
+    #
+    #     self.make_dummy_intputs()
+    #     self.output_uvfits_name = "unittest_diff_dimension.uvfits"
+    #     self.create_uvfits_outputs(num_freqs=2)
+    #
+    #     ##Contain things when they go wrong
+    #     with self.assertRaises(SystemExit) as cm:
+    #         ##This call to main should die
+    #         awu.main()
+    #
+    #     expec_fail_string = "Shape of the data in the uvfits are not the same. Data "\
+    #          "might have different number of times steps, frequencies, "\
+    #          "or baselines."
+    #     self.assertEqual(cm.exception.code, expec_fail_string)
+
+##Run the test
+if __name__ == '__main__':
+   unittest.main()

--- a/cmake_testing/run_woden/CMakeLists.txt
+++ b/cmake_testing/run_woden/CMakeLists.txt
@@ -34,13 +34,13 @@ add_test(python_test_make_baseline_date_arrays ${PYTHON_EXECUTABLE}
 add_test(python_test_remove_phase_tracking ${PYTHON_EXECUTABLE}
          ${CMAKE_CURRENT_SOURCE_DIR}/test_remove_phase_tracking.py)
 
-add_test(python_test_argument_inputs ${PYTHON_EXECUTABLE}
-         ${CMAKE_CURRENT_SOURCE_DIR}/test_argument_inputs.py)
-
 ##Set an environment variable for the ctest of this, so we can find a path
 ##to some test files that live in this dir
+add_test(python_test_argument_inputs ${PYTHON_EXECUTABLE}
+         ${CMAKE_CURRENT_SOURCE_DIR}/test_argument_inputs.py)
 set_tests_properties(python_test_argument_inputs PROPERTIES
          ENVIRONMENT CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR})
+
 #
 add_test(python_test_read_uvfits_into_pyuvdata ${PYTHON_EXECUTABLE}
          ${CMAKE_CURRENT_SOURCE_DIR}/test_read_uvfits_into_pyuvdata.py)

--- a/cmake_testing/run_woden/test_RTS_encoding.py
+++ b/cmake_testing/run_woden/test_RTS_encoding.py
@@ -27,10 +27,14 @@ class Test(unittest.TestCase):
         self.b1_4 = 1
         self.b2_4 = 2
 
+        self.b1_5 = 1
+        self.b2_5 = 1
+
         self.code1 = 58270
         self.code2 = 19440
         self.code3 = 31645
         self.code4 = 258
+        self.code5 = 257
 
     def test_RTS_encode_baseline(self):
         """Tests the `rw.RTS_encode_baseline` function, which should produce
@@ -45,6 +49,7 @@ class Test(unittest.TestCase):
         self.assertEqual(self.code2, rw.RTS_encode_baseline(self.b1_2, self.b2_2))
         self.assertEqual(self.code3, rw.RTS_encode_baseline(self.b1_3, self.b2_3))
         self.assertEqual(self.code4, rw.RTS_encode_baseline(self.b1_4, self.b2_4))
+        self.assertEqual(self.code5, rw.RTS_encode_baseline(self.b1_5, self.b2_5))
 
     def test_RTS_decode_baseline(self):
         """Tests the `rw.RTS_decode_baseline` function, which should split a
@@ -59,6 +64,7 @@ class Test(unittest.TestCase):
         b1_2, b2_2 = rw.RTS_decode_baseline(self.code2)
         b1_3, b2_3 = rw.RTS_decode_baseline(self.code3)
         b1_4, b2_4 = rw.RTS_decode_baseline(self.code4)
+        b1_5, b2_5 = rw.RTS_decode_baseline(self.code5)
 
         ##Test they match expectations
         self.assertEqual(b1_1, self.b1_1)
@@ -69,6 +75,9 @@ class Test(unittest.TestCase):
         self.assertEqual(b2_2, self.b2_2)
         self.assertEqual(b2_3, self.b2_3)
         self.assertEqual(b2_4, self.b2_4)
+
+        self.assertEqual(b1_5, self.b1_5)
+        self.assertEqual(b2_5, self.b2_5)
 
 ##Run the test
 if __name__ == '__main__':

--- a/cmake_testing/run_woden/test_argument_inputs.py
+++ b/cmake_testing/run_woden/test_argument_inputs.py
@@ -389,6 +389,25 @@ class Test(unittest.TestCase):
         self.assertEqual("[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]", args.MWA_FEE_delays)
 
 
+    def test_do_autos_work(self):
+        """Check that with a minimal set of arguments, the parser defaults to
+        no asking for autocorrelations, and check that this changes when
+        requested"""
+
+        ##Make minimum arguements, run parser, check do_autos == False
+        self.make_minimum_required_args_without_metafits()
+        args = self.run_parser_and_check_args()
+        self.assertEqual(False, args.do_autos)
+
+        ##Append the --do_autos flag, and check do_autos == True
+        self.inputs.append('--do_autos')
+        args = self.run_parser_and_check_args()
+        self.assertEqual(True, args.do_autos)
+
+
+
+
+
 ##Run the test
 if __name__ == '__main__':
     unittest.main()

--- a/cmake_testing/run_woden/test_load_data.py
+++ b/cmake_testing/run_woden/test_load_data.py
@@ -161,6 +161,204 @@ class Test(unittest.TestCase):
         self.assertTrue((np.all(v_container[:,0,0,:,2,2] == 1.0)))
         self.assertTrue((np.all(v_container[:,0,0,:,3,2] == 1.0)))
 
+    def reshape_v_container_autos(self, v_slice, num_baselines, num_ants,
+                                  num_freq_channels, num_time_steps):
+        """Reshape a real/imag single polarisation slice of v_container to match
+        the order of data in the WODEN binary file"""
+
+        num_visis = (num_baselines + num_ants)*num_freq_channels*num_time_steps
+        num_cross = num_baselines*num_freq_channels*num_time_steps
+
+        out_slice = np.empty(num_visis)
+
+        for time_ind in np.arange(num_time_steps):
+            for freq_ind in np.arange(num_freq_channels):
+
+                visi_ind = 0
+                auto_ind = 0
+                cross_ind = 0
+                for b1 in np.arange(num_ants):
+                    for b2 in np.arange(b1,num_ants):
+
+                        index_in = time_ind*(num_baselines + num_ants) + visi_ind
+
+                        if b1 == b2:
+                            index_out = num_cross + time_ind*num_ants*num_freq_channels + freq_ind*num_ants + auto_ind
+                            auto_ind += 1
+                        else:
+                            index_out = time_ind*num_baselines*num_freq_channels + freq_ind*num_baselines + cross_ind
+                            cross_ind += 1
+
+                        out_slice[index_out] = v_slice[index_in, freq_ind]
+
+                        visi_ind += 1
+
+        return out_slice
+
+    def load_data_autos(self, precision):
+        """Does the binary file writing/reading and comparisons, for either
+        precision=float or precision=double, when auto-correlations are
+        included"""
+
+        num_ants = 3
+        num_baselines = 3
+        num_freq_channels = 4
+        num_time_steps = 2
+
+        num_visis = (num_baselines + num_ants)*num_freq_channels*num_time_steps
+        num_cross = num_baselines*num_freq_channels*num_time_steps
+
+        ##In the real WODEN output, the u values are repeated for each frequency
+        ##as they are in metres. First make two different random sets of u,v,w
+        ##one for each time step.
+
+
+        input_u_t1 = np.random.uniform(-1000, 1000, num_baselines)
+        input_v_t1 = np.random.uniform(-1000, 1000, num_baselines)
+        input_w_t1 = np.random.uniform(-100, 100, num_baselines)
+
+        input_u_t2 = np.random.uniform(-1000, 1000, num_baselines)
+        input_v_t2 = np.random.uniform(-1000, 1000, num_baselines)
+        input_w_t2 = np.random.uniform(-100, 100, num_baselines)
+
+        ##Tile them up in the way the would come out of WODEN
+        ##When autos are included, they are dumped out at the end of the file,
+        ##and are all zeros
+        input_u = np.zeros(num_visis)
+        input_v = np.zeros(num_visis)
+        input_w = np.zeros(num_visis)
+
+        num_us = num_baselines*num_freq_channels
+
+        input_u[:num_us] = np.tile(input_u_t1, num_freq_channels)
+        input_v[:num_us] = np.tile(input_v_t1, num_freq_channels)
+        input_w[:num_us] = np.tile(input_w_t1, num_freq_channels)
+
+        input_u[num_us:2*num_us] = np.tile(input_u_t2, num_freq_channels)
+        input_v[num_us:2*num_us] = np.tile(input_v_t2, num_freq_channels)
+        input_w[num_us:2*num_us] = np.tile(input_w_t2, num_freq_channels)
+
+        ##make some fake visibilities
+        input_xx_re = np.random.uniform(-1000, 1000, num_visis)
+        input_xx_im = np.random.uniform(-1000, 1000, num_visis)
+        input_xy_re = np.random.uniform(-1000, 1000, num_visis)
+        input_xy_im = np.random.uniform(-1000, 1000, num_visis)
+        input_yx_re = np.random.uniform(-1000, 1000, num_visis)
+        input_yx_im = np.random.uniform(-1000, 1000, num_visis)
+        input_yy_re = np.random.uniform(-1000, 1000, num_visis)
+        input_yy_im = np.random.uniform(-1000, 1000, num_visis)
+
+        ##Essentially when writing the binary all the data goes into a massive
+        ##1D array, so assemble in correct order and write out
+
+        binary_array = np.empty(11*num_visis)
+        binary_array[0*num_visis:1*num_visis] = input_u
+        binary_array[1*num_visis:2*num_visis] = input_v
+        binary_array[2*num_visis:3*num_visis] = input_w
+        binary_array[3*num_visis:4*num_visis] = input_xx_re
+        binary_array[4*num_visis:5*num_visis] = input_xx_im
+        binary_array[5*num_visis:6*num_visis] = input_xy_re
+        binary_array[6*num_visis:7*num_visis] = input_xy_im
+        binary_array[7*num_visis:8*num_visis] = input_yx_re
+        binary_array[8*num_visis:9*num_visis] = input_yx_im
+        binary_array[9*num_visis:10*num_visis] = input_yy_re
+        binary_array[10*num_visis:11*num_visis] = input_yy_im
+
+        if precision == 'float':
+            ##Write them out to a binary file
+            filename = "test_load_data.dat"
+            binary_array.astype('float32').tofile(filename)
+
+        elif precision == 'double':
+            ##Write them out to a binary file
+            filename = "test_load_data.dat"
+            binary_array.astype('float64').tofile(filename)
+
+        ##Read in binary file using code under test
+        output_u, output_v, output_w, v_container = rw.load_data(filename=filename,
+                                                 num_baselines=num_baselines,
+                                                 num_freq_channels=num_freq_channels,
+                                                 num_time_steps=num_time_steps,
+                                                 precision=precision,
+                                                 do_autos=True,
+                                                 num_ants=num_ants)
+
+        ##Ok, a remapping has occured that mixes up the autos and the crosses
+        ##so work out that mapping so we can test our outputs
+
+        cross_map = []
+        auto_map = []
+
+        visi_map = 0
+        for b1 in np.arange(num_ants):
+            for b2 in np.arange(b1,num_ants):
+                if b1 == b2:
+                    auto_map.append(visi_map)
+                else:
+                    cross_map.append(visi_map)
+                visi_map += 1
+
+        cross_map = np.array(cross_map, dtype=int)
+        auto_map = np.array(auto_map, dtype=int)
+
+        ##Check the u,v,w positions are to millimetre precision
+        mm_accuracy = 1e-3 / VELC
+
+        ##First half of the output cross u,v,w should equal first time step u,v,w
+        ## need to apply the mapping to select the crosses
+        self.assertTrue(np.allclose(input_u_t1 / VELC, output_u[cross_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(input_v_t1 / VELC, output_v[cross_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(input_w_t1 / VELC, output_w[cross_map], atol=mm_accuracy))
+
+        # ##Same for the second half u,v,w
+        self.assertTrue(np.allclose(input_u_t2 / VELC, output_u[num_baselines + num_ants + cross_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(input_v_t2 / VELC, output_v[num_baselines + num_ants + cross_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(input_w_t2 / VELC, output_w[num_baselines + num_ants + cross_map], atol=mm_accuracy))
+
+        ##Check that the autos have zero u,v,w
+        self.assertTrue(np.allclose(0.0, output_u[auto_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(0.0, output_v[auto_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(0.0, output_w[auto_map], atol=mm_accuracy))
+
+        # ##Same for the second half u,v,w
+        self.assertTrue(np.allclose(0.0, output_u[num_baselines + num_ants + auto_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(0.0, output_v[num_baselines + num_ants + auto_map], atol=mm_accuracy))
+        self.assertTrue(np.allclose(0.0, output_w[num_baselines + num_ants + auto_map], atol=mm_accuracy))
+
+        ##Reshape the data read in from binary file to what was input
+        output_xx_re = self.reshape_v_container_autos(v_container[:,0,0,:,0,0],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_xx_im = self.reshape_v_container_autos(v_container[:,0,0,:,0,1],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_xy_re = self.reshape_v_container_autos(v_container[:,0,0,:,2,0],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_xy_im = self.reshape_v_container_autos(v_container[:,0,0,:,2,1],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_yx_re = self.reshape_v_container_autos(v_container[:,0,0,:,3,0],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_yx_im = self.reshape_v_container_autos(v_container[:,0,0,:,3,1],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_yy_re = self.reshape_v_container_autos(v_container[:,0,0,:,1,0],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+        output_yy_im = self.reshape_v_container_autos(v_container[:,0,0,:,1,1],
+                            num_baselines, num_ants, num_freq_channels, num_time_steps)
+
+        # ##Test things are what they're supposed to be
+        self.assertTrue(np.allclose(input_xx_re, output_xx_re, atol=1e-10))
+        self.assertTrue(np.allclose(input_xx_im, output_xx_im, atol=1e-10))
+        self.assertTrue(np.allclose(input_xy_re, output_xy_re, atol=1e-10))
+        self.assertTrue(np.allclose(input_xy_im, output_xy_im, atol=1e-10))
+        self.assertTrue(np.allclose(input_yx_re, output_yx_re, atol=1e-10))
+        self.assertTrue(np.allclose(input_yx_im, output_yx_im, atol=1e-10))
+        self.assertTrue(np.allclose(input_yy_re, output_yy_re, atol=1e-10))
+        self.assertTrue(np.allclose(input_yy_im, output_yy_im, atol=1e-10))
+        #
+        # ##The weights should all be one
+        self.assertTrue((np.all(v_container[:,0,0,:,0,2] == 1.0)))
+        self.assertTrue((np.all(v_container[:,0,0,:,1,2] == 1.0)))
+        self.assertTrue((np.all(v_container[:,0,0,:,2,2] == 1.0)))
+        self.assertTrue((np.all(v_container[:,0,0,:,3,2] == 1.0)))
+
     def test_load_data_float(self):
         """Runs the test in float precision"""
         self.load_data('float')
@@ -168,6 +366,14 @@ class Test(unittest.TestCase):
     def test_load_data_double(self):
         """Runs the test in double precision"""
         self.load_data('double')
+
+    def test_load_data_autos_float(self):
+        """Runs the test in float precision"""
+        self.load_data_autos('float')
+
+    def test_load_data_autos_double(self):
+        """Runs the test in double precision"""
+        self.load_data_autos('double')
 
 ##Run the test
 if __name__ == '__main__':

--- a/cmake_testing/run_woden/test_make_baseline_date_arrays.py
+++ b/cmake_testing/run_woden/test_make_baseline_date_arrays.py
@@ -13,7 +13,7 @@ import run_woden as rw
 
 ##Vehicle for running tests
 class Test(unittest.TestCase):
-    def test_make_baseline_date_arrays(self):
+    def test_make_baseline_date_arrays_noautos(self):
         """Tests the `rw.make_baseline_date_arrays` function, which should make
         the DATE and BASELINE arrays that are needed to populate a uvfits file"""
 
@@ -37,6 +37,45 @@ class Test(unittest.TestCase):
                                    0.04461805541, 0.04461805541, 0.04461805541,
                                    0.04464120356, 0.04464120356, 0.04464120356,
                                    0.04464120356, 0.04464120356, 0.04464120356])
+
+        ##Check the outputs are within 1e-10 of expected values
+        self.assertTrue(np.allclose(expected_baselines, baselines_array, atol=1e-10))
+        self.assertTrue(np.allclose(expected_dates, date_array, atol=1e-10))
+
+    def test_make_baseline_date_arrays_withautos(self):
+        """Tests the `rw.make_baseline_date_arrays` function, which should make
+        the DATE and BASELINE arrays that are needed to populate a uvfits file"""
+
+        ##Run the code with an example date
+        date = "2019-06-12T13:04:12"
+
+        num_antennas = 4
+        num_time_steps = 3
+        time_res = 2.0
+
+        baselines_array, date_array = rw.make_baseline_date_arrays(num_antennas,
+                                                 date, num_time_steps, time_res,
+                                                 do_autos=True)
+
+        expected_baselines = np.array([257, 258, 259, 260, 514,
+                                       515, 516, 771, 772, 1028,
+                                       257, 258, 259, 260, 514,
+                                       515, 516, 771, 772, 1028,
+                                       257, 258, 259, 260, 514,
+                                       515, 516, 771, 772, 1028])
+
+        expected_dates = np.array([0.04459490726, 0.04459490726, 0.04459490726,
+                                   0.04459490726, 0.04459490726, 0.04459490726,
+                                   0.04459490726, 0.04459490726, 0.04459490726,
+                                   0.04459490726,
+                                   0.04461805541, 0.04461805541, 0.04461805541,
+                                   0.04461805541, 0.04461805541, 0.04461805541,
+                                   0.04461805541, 0.04461805541, 0.04461805541,
+                                   0.04461805541,
+                                   0.04464120356, 0.04464120356, 0.04464120356,
+                                   0.04464120356, 0.04464120356, 0.04464120356,
+                                   0.04464120356, 0.04464120356, 0.04464120356,
+                                   0.04464120356])
 
         ##Check the outputs are within 1e-10 of expected values
         self.assertTrue(np.allclose(expected_baselines, baselines_array, atol=1e-10))

--- a/cmake_testing/run_woden/test_write_json.py
+++ b/cmake_testing/run_woden/test_write_json.py
@@ -41,6 +41,7 @@ class PretendArgs():
         self.gauss_dec_point = False
         self.MWA_FEE_delays = False
         self.no_precession = False
+        self.do_autos = False
 
     def __init__(self):
         self.make_basic_args()
@@ -214,13 +215,13 @@ class Test(unittest.TestCase):
         ##Check the extra arguments have resulting in correct outputs
         self.assertTrue(self.data['use_EDA2_beam'])
 
-    def test_write_no_precession(self):
+    def test_write_do_autos(self):
         """Test that no_precession is written when selected in args"""
 
         ##Some input test params
-        self.make_basic_inputs("test_write_np_precess.json")
+        self.make_basic_inputs("test_write_do_autos.json")
         ##Add in primary_beam as Gaussian to inputs
-        self.args.no_precession = True
+        self.args.do_autos = True
 
         ##Code to be tested
         self.call_write_json()
@@ -229,7 +230,7 @@ class Test(unittest.TestCase):
         self.check_basic_inputs()
 
         ##Check the extra arguments have resulting in correct outputs
-        self.assertTrue(self.data['no_precession'])
+        self.assertTrue(self.data['do_autos'])
 
 ##Run the test
 if __name__ == '__main__':

--- a/cmake_testing/source_components/CMakeLists.txt
+++ b/cmake_testing/source_components/CMakeLists.txt
@@ -162,4 +162,20 @@ foreach(PRECISION IN LISTS FLOAT DOUBLE)
   add_test(CUDA_test_update_sum_visis_${PRECISION}
            test_update_sum_visis_${PRECISION}_app)
 
+
+  # ##Test the function that calculates the autocorrelations
+  add_executable(test_kern_calc_autos_${PRECISION}_app
+      test_kern_calc_autos.c
+      ${CMAKE_SOURCE_DIR}/src/visibility_set.c
+  )
+  target_link_libraries(test_kern_calc_autos_${PRECISION}_app
+      source_componentsCUDA_${PRECISION}
+      ${CC_LINKLIBS}
+      Unity
+  )
+  target_compile_options(test_kern_calc_autos_${PRECISION}_app
+                         PRIVATE ${C_FLAGS})
+  add_test(CUDA_test_kern_calc_autos_${PRECISION}
+           test_kern_calc_autos_${PRECISION}_app)
+
 endforeach()

--- a/cmake_testing/source_components/test_extrap_stokes.c
+++ b/cmake_testing/source_components/test_extrap_stokes.c
@@ -127,8 +127,6 @@ void test_kern_extrap_stokes_GivesCorrectValues(void) {
                         extrap_freqs, num_extrap_freqs,
                         expec_flux_I, expec_flux_Q, expec_flux_U, expec_flux_V);
 
-
-
   for (int i = 0; i < num_extrap_freqs*(num_powers + num_curves + num_lists); i++) {
     //Check the two are within tolerace
     // printf("%d %.3f %.3f\n",i, expec_flux_I[i], extrap_flux_I[i] );

--- a/cmake_testing/source_components/test_kern_calc_autos.c
+++ b/cmake_testing/source_components/test_kern_calc_autos.c
@@ -1,0 +1,283 @@
+/*
+Tests that the kernel that calculates auto-correlations is doing it's job
+*/
+#include <math.h>
+#include <unity.h>
+#include <stdlib.h>
+#include <complex.h>
+
+#include "constants.h"
+#include "woden_struct_defs.h"
+// #include "shapelet_basis.h"
+#include "woden_settings.h"
+#include "visibility_set.h"
+
+
+#ifdef DOUBLE_PRECISION
+  double TOL = 1e-12;
+#else
+  double TOL = 1e-2;
+#endif
+
+void setUp (void) {} /* Is run before every test, put unit init calls here. */
+void tearDown (void) {} /* Is run after every test, put unit clean-up calls here. */
+
+
+//External CUDA code being linked in
+extern void test_kern_calc_autos(components_t *components, int beamtype,
+                                 int num_components, int num_baselines,
+                                 int num_freqs, int num_times, int num_ants,
+                                 visibility_set_t *visibility_set);
+
+
+/*
+For a given beam model, calculate the auto-correlations
+*/
+void test_calculate_autos(e_beamtype beamtype) {
+
+  int num_comps = 4;
+  int num_times = 2;
+  int num_freqs = 3;
+
+  int num_ants = 3;
+  int num_baselines = (num_ants*(num_ants - 1)) / 2;
+
+  int num_cross = num_baselines*num_times*num_freqs;
+  int num_autos = num_ants*num_times*num_freqs;
+  int num_visis = num_cross + num_autos;
+
+  int num_pb_values = num_freqs*num_times*num_comps;
+
+  components_t *components = malloc(sizeof(components_t));
+
+  //need to fill in the following:
+  components->extrap_stokesI =  malloc(num_comps*num_freqs*sizeof(user_precision_t));
+  components->extrap_stokesQ =  malloc(num_comps*num_freqs*sizeof(user_precision_t));
+  components->extrap_stokesU =  malloc(num_comps*num_freqs*sizeof(user_precision_t));
+  components->extrap_stokesV =  malloc(num_comps*num_freqs*sizeof(user_precision_t));
+  components->gxs =  malloc(num_pb_values*sizeof(user_precision_complex_t));
+  components->Dxs =  malloc(num_pb_values*sizeof(user_precision_complex_t));
+  components->Dys =  malloc(num_pb_values*sizeof(user_precision_complex_t));
+  components->gys =  malloc(num_pb_values*sizeof(user_precision_complex_t));
+
+  user_precision_complex_t *expec_XXs = malloc(num_autos*sizeof(user_precision_complex_t));
+  user_precision_complex_t *expec_XYs = malloc(num_autos*sizeof(user_precision_complex_t));
+  user_precision_complex_t *expec_YXs = malloc(num_autos*sizeof(user_precision_complex_t));
+  user_precision_complex_t *expec_YYs = malloc(num_autos*sizeof(user_precision_complex_t));
+
+  user_precision_complex_t expec_XX, expec_XY, expec_YX, expec_YY;
+
+  int flux_ind = 0;
+  int beam_ind = 0;
+  double flux_value = 1;
+  double beam_value = 0;
+  int auto_stripe;
+
+  //Flux density of componets don't change with time, just frequency
+  for (int comp = 0; comp < num_comps; comp++) {
+    for (int freq = 0; freq < num_freqs; freq++) {
+
+      flux_ind = num_freqs*comp + freq;
+
+      expec_XX = 0.0 + 0.0*I;
+
+      components->extrap_stokesI[flux_ind] = flux_value;
+      components->extrap_stokesQ[flux_ind] = 0;
+      components->extrap_stokesU[flux_ind] = 0;
+      components->extrap_stokesV[flux_ind] = 0;
+
+      flux_value ++;
+
+
+    }
+  }
+
+  // for (int i = 0; i < num_comps*num_freqs; i++) {
+  //   printf("%.1f\n",components->extrap_stokesI[i] );
+  // }
+
+  user_precision_complex_t expec_I;
+
+  user_precision_complex_t gx, Dx, Dy, gy;
+
+  //Beam values also change with time as well as freq and direction
+  for (int time = 0; time < num_times; time++) {
+    for (int freq = 0; freq < num_freqs; freq++) {
+
+      expec_XX = 0.0 + 0.0*I;
+      expec_XY = 0.0 + 0.0*I;
+      expec_YX = 0.0 + 0.0*I;
+      expec_YY = 0.0 + 0.0*I;
+
+      for (int comp = 0; comp < num_comps; comp++) {
+
+        gx = beam_value + 0.2 + 0.2*I;
+        Dx = beam_value + 0.4 + 0.4*I;
+        Dy = beam_value + 0.6 + 0.6*I;
+        gy = beam_value + 0.8 + 0.8*I;
+
+        components->gxs[beam_ind] = gx;
+        components->Dxs[beam_ind] = Dx;
+        components->Dys[beam_ind] = Dy;
+        components->gys[beam_ind] = gy;
+
+        flux_ind = num_freqs*comp + freq;
+
+        expec_I = components->extrap_stokesI[flux_ind] + 0*I;
+
+        if (beamtype == NO_BEAM) {
+          expec_XX += expec_I;
+          expec_YY += expec_I;
+        }
+
+        //Only MWA models have leakge terms at the moment
+       else if (beamtype == FEE_BEAM || beamtype == FEE_BEAM_INTERP || beamtype == MWA_ANALY) {
+         expec_XX += (gx*conj(gx) + Dx*conj(Dx))*expec_I;
+         expec_XY += (gx*conj(Dy) + conj(gy)*Dx)*expec_I;
+         expec_YX += (Dy*conj(gx) + gy*conj(Dx))*expec_I;
+         expec_YY += (gy*conj(gy) + Dy*conj(Dy))*expec_I;
+       }
+
+       else{
+          expec_XX += (gx*conj(gx))*expec_I;
+          expec_YY += (gy*conj(gy))*expec_I;
+        }
+
+        beam_value ++;
+        beam_ind ++;
+
+      }
+
+      for (int ant = 0; ant < num_ants; ant++) {
+        auto_stripe = num_ants*num_freqs*time + num_ants*freq + ant;
+        expec_XXs[auto_stripe] = expec_XX;
+        expec_XYs[auto_stripe] = expec_XY;
+        expec_YXs[auto_stripe] = expec_YX;
+        expec_YYs[auto_stripe] = expec_YY;
+      }
+
+    }
+  }
+
+  //Setup chunk_visibility_set to hold the visibility outputs of each
+  visibility_set_t *visibility_set = setup_visibility_set(num_visis);
+
+  //Set it all to zero to start
+  for (int visi = 0; visi < num_visis; visi++) {
+    visibility_set->sum_visi_XX_real[visi] = 0;
+    visibility_set->sum_visi_XX_imag[visi] = 0;
+    visibility_set->sum_visi_XY_real[visi] = 0;
+    visibility_set->sum_visi_XY_imag[visi] = 0;
+    visibility_set->sum_visi_YX_real[visi] = 0;
+    visibility_set->sum_visi_YX_imag[visi] = 0;
+    visibility_set->sum_visi_YY_imag[visi] = 0;
+    visibility_set->sum_visi_YY_real[visi] = 0;
+  }
+
+  test_kern_calc_autos(components, beamtype,
+                       num_comps, num_baselines,
+                       num_freqs, num_times, num_ants,
+                       visibility_set);
+
+  //Function shouldn't touch the cross-correlation part of the output visis
+  //so check that everything is zero
+  for (int cross = 0; cross < num_cross; cross++) {
+
+
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_XX_real[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_XX_imag[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_XY_real[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_XY_imag[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_YX_real[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_YX_imag[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_YY_imag[cross]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, 0.0, visibility_set->sum_visi_YY_real[cross]);
+  }
+
+  for (int autos = 0; autos < num_autos; autos++) {
+
+    // printf("XX expec, calc %.1f %.1f\n",creal(expec_XXs[autos]), visibility_set->sum_visi_XX_real[num_cross + autos] );
+    // printf("XY expec, calc %.1f %.1f\n",creal(expec_XYs[autos]), visibility_set->sum_visi_XY_real[num_cross + autos] );
+    // printf("YX expec, calc %.1f %.1f\n",creal(expec_YXs[autos]), visibility_set->sum_visi_YX_real[num_cross + autos] );
+    // printf("YY expec, calc %.1f %.1f\n",creal(expec_YYs[autos]), visibility_set->sum_visi_YY_real[num_cross + autos] );
+  //
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, creal(expec_XXs[autos]),
+                      visibility_set->sum_visi_XX_real[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, cimag(expec_XXs[autos]),
+                      visibility_set->sum_visi_XX_imag[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, creal(expec_XYs[autos]),
+                      visibility_set->sum_visi_XY_real[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, cimag(expec_XYs[autos]),
+                      visibility_set->sum_visi_XY_imag[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, creal(expec_YXs[autos]),
+                      visibility_set->sum_visi_YX_real[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, cimag(expec_YXs[autos]),
+                      visibility_set->sum_visi_YX_imag[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, creal(expec_YYs[autos]),
+                      visibility_set->sum_visi_YY_real[num_cross + autos]);
+    TEST_ASSERT_DOUBLE_WITHIN(TOL, cimag(expec_YYs[autos]),
+                      visibility_set->sum_visi_YY_imag[num_cross + autos]);
+ }
+
+  free(visibility_set->sum_visi_XX_real);
+  free(visibility_set->sum_visi_XX_imag);
+  free(visibility_set->sum_visi_XY_real);
+  free(visibility_set->sum_visi_XY_imag);
+  free(visibility_set->sum_visi_YX_real);
+  free(visibility_set->sum_visi_YX_imag);
+  free(visibility_set->sum_visi_YY_real);
+  free(visibility_set->sum_visi_YY_imag);
+
+  free(components->extrap_stokesI);
+  free(components->extrap_stokesQ);
+  free(components->extrap_stokesU);
+  free(components->extrap_stokesV);
+  free(components->gxs);
+  free(components->Dxs);
+  free(components->Dys);
+  free(components->gys);
+
+  free(expec_XXs);
+
+}
+
+void test_calculate_autos_NoBeam(void) {
+  test_calculate_autos(NO_BEAM);
+}
+
+void test_calculate_autos_GaussBeam(void) {
+  test_calculate_autos(GAUSS_BEAM);
+}
+
+void test_calculate_autos_EDA2Beam(void) {
+  test_calculate_autos(ANALY_DIPOLE);
+}
+
+void test_calculate_autos_MWAAnaly(void) {
+  test_calculate_autos(ANALY_DIPOLE);
+}
+
+void test_calculate_autos_MWAFEE(void) {
+  test_calculate_autos(FEE_BEAM);
+}
+
+void test_calculate_autos_MWAFEEInterp(void) {
+  test_calculate_autos(FEE_BEAM_INTERP);
+}
+
+
+//Run the test with unity
+int main(void)
+{
+    UNITY_BEGIN();
+    //Test with a single SOURCE, single COMPONENT
+
+    RUN_TEST(test_calculate_autos_NoBeam);
+    RUN_TEST(test_calculate_autos_GaussBeam);
+    RUN_TEST(test_calculate_autos_EDA2Beam);
+    RUN_TEST(test_calculate_autos_MWAAnaly);
+    RUN_TEST(test_calculate_autos_MWAFEE);
+    RUN_TEST(test_calculate_autos_MWAFEEInterp);
+
+    return UNITY_END();
+}

--- a/cmake_testing/woden_settings/CMakeLists.txt
+++ b/cmake_testing/woden_settings/CMakeLists.txt
@@ -21,9 +21,10 @@ set(J9 "example_array_layout.txt")
 set(J10 "run_woden_noprecession.json")
 set(J11 "run_woden_MWA_analy.json")
 set(J12 "run_woden_MWAFEE_interp.json")
+set(J12 "run_woden_doautos.json")
 
 ## Loop through them and write a symlink so the testing executable can find them
-foreach(X IN LISTS J1 J2 J3 J4 J5 J6 J7 J8 J9 J10 J11 J12)
+foreach(X IN LISTS J1 J2 J3 J4 J5 J6 J7 J8 J9 J10 J11 J12 J13)
     ADD_CUSTOM_TARGET(targetthis_${X} ALL
         COMMAND ${CMAKE_COMMAND} -E create_symlink "${JSON_PATH}/${X}" "${X}")
 endforeach()

--- a/cmake_testing/woden_settings/run_woden_doautos.json
+++ b/cmake_testing/woden_settings/run_woden_doautos.json
@@ -1,0 +1,19 @@
+{
+  "ra0": 0.0000000000,
+  "dec0": -27.0000000000,
+  "num_freqs": 16,
+  "num_time_steps": 4,
+  "cat_filename": "srclist_singlepoint.txt",
+  "time_res": 2.0,
+  "frequency_resolution": 40000.0,
+  "chunking_size": 5000,
+  "jd_date": 2457278.2010995,
+  "LST": 0.44312771,
+  "array_layout": "example_array_layout.txt",
+  "lowest_channel_freq": 1.6703500000e+08,
+  "latitude": -26.70331944,
+  "coarse_band_width": 1.2800000000e+06,
+  "sky_crop_components": True,
+  "band_nums": [1,4,9],
+  "do_autos": True
+}

--- a/cmake_testing/woden_settings/test_read_json_settings.c
+++ b/cmake_testing/woden_settings/test_read_json_settings.c
@@ -15,7 +15,8 @@ void tearDown (void) {} /* Is run after every test, put unit clean-up calls here
 Check that the values in the json that aren't beam specific are read in
 correctly
 */
-void check_observation_params(woden_settings_t *woden_settings) {
+void check_observation_params(woden_settings_t *woden_settings,
+                              int expec_precess, int expec_autos) {
 
   TEST_ASSERT_EQUAL_DOUBLE(-26.70331944*DD2R,woden_settings->latitude);
   TEST_ASSERT_EQUAL_DOUBLE(0.44312771*DD2R, woden_settings->lst_base);
@@ -40,6 +41,22 @@ void check_observation_params(woden_settings_t *woden_settings) {
 
   TEST_ASSERT_EQUAL_INT(CROP_COMPONENTS, woden_settings->sky_crop_type);
 
+  if (expec_precess) {
+    //Check precession beam specific value - should be switched off now
+    TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
+  } else {
+    //Check precession beam specific value - should be switched off now
+    TEST_ASSERT_EQUAL_INT(0, woden_settings->do_precession);
+  }
+
+  if (expec_autos) {
+    //Check precession beam specific value - should be switched off now
+    TEST_ASSERT_EQUAL_INT(1, woden_settings->do_autos);
+  } else {
+    //Check precession beam specific value - should be switched off now
+    TEST_ASSERT_EQUAL_INT(0, woden_settings->do_autos);
+  }
+
 }
 
 /*
@@ -56,9 +73,9 @@ void test_read_json_settings_MWAFEE(void) {
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
-  //Check precession is switched on (default)
-  TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
+  int expec_precess = 1;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
   //Check MWA FEE beam specific values
   user_precision_t expect_delays[] = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
@@ -79,13 +96,13 @@ void test_read_json_settings_GaussBeam(char *json_path, int default_gauss) {
   //Read in the settings from the controlling json file
   woden_settings_t *woden_settings = malloc( sizeof(woden_settings_t) );
   status = read_json_settings(json_path, woden_settings);
-  //Check precession is switched on (default)
-  TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
 
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
+  int expec_precess = 1;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
   TEST_ASSERT_EQUAL_DOUBLE(56.13129905*DD2R, woden_settings->gauss_ra_point);
   TEST_ASSERT_EQUAL_DOUBLE(-39.47577940*DD2R, woden_settings->gauss_dec_point);
@@ -136,9 +153,9 @@ void test_read_json_settings_EDA2(void) {
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
-  //Check precession is switched on (default)
-  TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
+  int expec_precess = 1;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
   //Check EDA2 beam specific value
   TEST_ASSERT_EQUAL_INT(ANALY_DIPOLE, woden_settings->beamtype);
@@ -159,9 +176,9 @@ void test_read_json_settings_NoBeam(void) {
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
-  //Check precession is switched on (default)
-  TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
+  int expec_precess = 1;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
   //Check EDA2 beam specific value
   TEST_ASSERT_EQUAL_INT(NO_BEAM, woden_settings->beamtype);
@@ -216,7 +233,7 @@ void test_read_json_settings_MWAFEENoPath(void) {
 
 /*
 Read in a json settings file and check values are good
-Check that using no beam is selected
+Check that using no precession is selected
 */
 void test_read_json_settings_NoPrecession(void) {
 
@@ -228,10 +245,9 @@ void test_read_json_settings_NoPrecession(void) {
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
-
-  //Check precession beam specific value - should be switched off now
-  TEST_ASSERT_EQUAL_INT(0, woden_settings->do_precession);
+  int expec_precess = 0;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
 }
 
@@ -249,9 +265,9 @@ void test_read_json_settings_MWAanaly(void) {
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
-  //Check precession is switched on (default)
-  TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
+  int expec_precess = 1;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
   //Check MWA FEE beam specific values
   user_precision_t expect_delays[] = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
@@ -273,9 +289,9 @@ void test_read_json_settings_MWAFEE_interp(void) {
   TEST_ASSERT_EQUAL_INT(0, status);
 
   //Check generic observation params have been read in correctly
-  check_observation_params(woden_settings);
-  //Check precession is switched on (default)
-  TEST_ASSERT_EQUAL_INT(1, woden_settings->do_precession);
+  int expec_precess = 1;
+  int expec_autos = 0;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
 
   //Check MWA FEE beam specific values
   user_precision_t expect_delays[] = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
@@ -286,6 +302,26 @@ void test_read_json_settings_MWAFEE_interp(void) {
                             woden_settings->hdf5_beam_path);
 }
 
+
+/*
+Read in a json settings file and check values are good
+Check that using no precession is selected
+*/
+void test_read_json_settings_DoAutos(void) {
+
+  int status=0;
+  //Read in the settings from the controlling json file
+  woden_settings_t *woden_settings = malloc( sizeof(woden_settings_t) );
+  status = read_json_settings("run_woden_doautos.json", woden_settings);
+
+  TEST_ASSERT_EQUAL_INT(0, status);
+
+  //Check generic observation params have been read in correctly
+  int expec_precess = 1;
+  int expec_autos = 1;
+  check_observation_params(woden_settings, expec_precess, expec_autos);
+
+}
 
 
 //Run test using unity
@@ -304,6 +340,7 @@ int main(void)
     RUN_TEST(test_read_json_settings_NoPrecession);
     RUN_TEST(test_read_json_settings_MWAanaly);
     RUN_TEST(test_read_json_settings_MWAFEE_interp);
+    RUN_TEST(test_read_json_settings_DoAutos);
 
     return UNITY_END();
 }

--- a/docs/sphinx/API_reference/API_index.rst
+++ b/docs/sphinx/API_reference/API_index.rst
@@ -20,8 +20,10 @@ can be reproduced on the command line using ``script.py --help``.
   :maxdepth: 1
 
   python_code/run_woden
-  python_code/convert_WSClean_list_to_WODEN
+  python_code/add_woden_uvfits
+  python_code/concat_woden_uvfits
   python_code/uv2ms
+  python_code/convert_WSClean_list_to_WODEN
 
 ``C`` code
 ----------------------

--- a/docs/sphinx/API_reference/python_code/add_woden_uvfits.rst
+++ b/docs/sphinx/API_reference/python_code/add_woden_uvfits.rst
@@ -1,0 +1,26 @@
+``add_woden_uvfits.py``
+========================
+
+Helper script to add visibilities inside of two sets of ``uvfits`` files.
+Useful for example if you have a set of 21cm signal visibilities that you want
+to add different types of foregrounds to; you only have to run the 21cm
+simulation once, then run different foregrounds with the same observational
+settings, and just add the foregrounds on top as visibilities are additive.
+
+.. warning:: This script is pretty dumb, so as long as the data have the same shape it will add the contents - it does NOT check if they have the same phase centre, frequencies, time stamps, etc. etc. use at your own risk
+
+.. _add_woden_uvfits command line running options:
+
+*Command line running options*
+-------------------------------
+
+.. argparse::
+   :filename: ../../src/add_woden_uvfits.py
+   :func: get_parser
+   :prog: add_woden_uvfits.py
+
+*Function documentation*
+------------------------
+
+.. automodule:: add_woden_uvfits
+   :members:

--- a/docs/sphinx/API_reference/python_code/concat_woden_uvfits.rst
+++ b/docs/sphinx/API_reference/python_code/concat_woden_uvfits.rst
@@ -1,0 +1,24 @@
+``concat_woden_uvfits.py``
+===========================
+
+Helper script to concatenate a number of uvfits files by frequency into a
+single uvfits file. Essential to input ``WODEN`` simulations into ``hyperdrive``.
+
+
+.. warning:: This script is pretty dumb, so as long as the script can find the uvfits files, it will do the concatenation - it does NOT check if they have the same phase centre, frequencies, time stamps, etc. etc. so use at your own risk
+
+.. _concat_woden_uvfits command line running options:
+
+*Command line running options*
+-------------------------------
+
+.. argparse::
+   :filename: ../../src/concat_woden_uvfits.py
+   :func: get_parser
+   :prog: concat_woden_uvfits.py
+
+*Function documentation*
+------------------------
+
+.. automodule:: concat_woden_uvfits
+   :members:

--- a/docs/sphinx/API_reference/python_code/convert_WSClean_list_to_WODEN.rst
+++ b/docs/sphinx/API_reference/python_code/convert_WSClean_list_to_WODEN.rst
@@ -13,3 +13,9 @@ sky model compatible with ``WODEN``.
    :filename: ../../src/convert_WSClean_list_to_WODEN.py
    :func: get_parser
    :prog: convert_WSClean_list_to_WODEN.py
+
+.. *Function documentation*
+.. ------------------------
+..
+.. .. automodule:: convert_WSClean_list_to_WODEN
+..    :members:

--- a/docs/sphinx/API_reference/python_code/uv2ms.rst
+++ b/docs/sphinx/API_reference/python_code/uv2ms.rst
@@ -12,3 +12,9 @@ Helper script to convert ``uvfits`` files to ``measurement sets`` using ``casa``
    :filename: ../../src/uv2ms.py
    :func: get_parser
    :prog: uv2ms.py
+
+*Function documentation*
+------------------------
+
+.. automodule:: uv2ms
+   :members:

--- a/docs/sphinx/testing/cmake_testing/array_layout.rst
+++ b/docs/sphinx/testing/cmake_testing/array_layout.rst
@@ -46,3 +46,17 @@ These tests simply provide a set of known input coords (read in from
 ``example_array_layout.txt``), runs ``array_layout::calc_XYZ_diffs`` for both
 the precession and no precession cases, and check the output values match the
 expected values stored in ``test_RTS_XYZ_common.h``.
+
+``calc_XYZ_diffs`` also sets the basic values of::
+
+   woden_settings->num_visis
+   woden_settings->num_ants
+   woden_settings->num_baselines
+   woden_settings->num_cross
+   woden_settings->num_autos
+
+which are used at various times during the rest of the simulation. The
+value of ``num_autos`` depends on whether the user has elicited to calculate
+auto-correlations, so should be 0 if ``woden_settings->do_autos`` if False,
+and correctly set if True. The numbers above are tested in both the False
+and True cases.

--- a/docs/sphinx/testing/cmake_testing/calculate_visibilities.rst
+++ b/docs/sphinx/testing/cmake_testing/calculate_visibilities.rst
@@ -92,9 +92,13 @@ should be fully real, and equal to the sum of the number of
 COMPONENTs in the sky model multiplied by 0.3333333333333333. This numerical 1/3
 flux is a good test of the precision of the FLOAT and DOUBLE compiled codes.
 
+.. note::
+
+	Given all sources are at phase centre, this means the cross-correlations and the auto-correlations should have exactly the same values. So in all tests described below, ``calculate_visibilities`` is run with both ``woden_settings->do_autos`` set to 0 and to 1. If the autos are calculated, the number of output visibilities should double (as I only simulate three baselines from three antennas here). The latter half are where the autos are set, and are tested to be equal to the expected values for the crosses.
+
 When the tests have a single COMPONENT per SOURCE, I use a POWER_LAW type flux
 behaviour. When there are three COMPONENTs, I use one of each of POWER_LAW,
-CURVED_POWER_LAW, and LIST types. 
+CURVED_POWER_LAW, and LIST types.
 
 GAUSSIAN and SHAPELET components with any size cause a reduction of the real part
 of the visibility due to the extended size on the sky. For these tests, I've set

--- a/docs/sphinx/testing/cmake_testing/source_components.rst
+++ b/docs/sphinx/testing/cmake_testing/source_components.rst
@@ -799,3 +799,24 @@ three sets of tests consist of:
 Each set of tests is run for all primary beam types, for a total of 18 tests.
 The different beam models have different expected values depending on whether
 they include leakage terms or not.
+
+test_kern_calc_autos.c
+************************************
+This calls ``source_components::test_kern_calc_autos``, which in turn calls
+``source_components::kern_calc_autos``. This kernel gathers pre-calculated
+primary beam values, and Stokes flux densities, and performs a dot-product
+to calculate the auto-correlations of all antennas, for all time steps.
+
+This test runs by creating a Stokes I sky model of 4 components, extrapolated
+to three frequencies and two time steps. Complex beam gains are generated for all
+directions, times, and frequencies. The auto-correlation calculation is then
+performed by ``C`` code, which the outputs of the GPU code are tested against.
+
+As some primary beam models are real only, and only some have leakage, the
+function is tested for all beam model types separately, with the expected
+outcomes calculated accordingly.
+
+The ``woden_double`` code is tested to an absolute precision of 1e-12 Jy,
+with the ``woden_float`` a 1e-2 Jy precision as compared to the ``C`` code
+(note some of the resultant fluxes are >10,000 Jy, hence the large absolute
+error. You should probably just always use the double precision version).

--- a/docs/sphinx/testing/cmake_testing/woden_settings.rst
+++ b/docs/sphinx/testing/cmake_testing/woden_settings.rst
@@ -43,6 +43,8 @@ eventualities.
    :widths: 25 50
    :header-rows: 1
 
+   * - Test file
+     - Test case
    * - run_woden_nobeam.json
      - The NO_BEAM primary beam is selected
    * - run_woden_EDA2.json
@@ -65,6 +67,8 @@ eventualities.
      - Contains multiple primary beam selections so should throw an error
    * - run_woden_noprecession.json
      - Checks that precession is switched off if requested
+   * - run_woden_doautos.json
+     - Checks that auto-correlations are set to be calculated if requested
 
 ``test_setup_lsts_and_phase_centre.c``
 *****************************************

--- a/include/fundamental_coords.h
+++ b/include/fundamental_coords.h
@@ -72,7 +72,7 @@ steps (metres)
 baselines, frequencies, and time steps
 @param[in] d_sha0s Sine of the hour angle of the phase centre for all
 baselines, frequencies, and time steps
-@param[in] num_visis Total number of `u,v,w` coords to be calculated
+@param[in] num_cross Total number of `u,v,w` coords to be calculated (number of cross correlations)
 @param[in] num_baselines Number of baselines for a single time step
 @param[in] num_times Number of time steps
 @param[in] num_freqs Number of frequency steps
@@ -83,7 +83,7 @@ __global__ void kern_calc_uvw(double *d_X_diff, double *d_Y_diff,
            user_precision_t *d_u, user_precision_t *d_v, user_precision_t *d_w, user_precision_t *d_wavelengths,
            double sdec0, double cdec0,
            double *d_cha0s, double *d_sha0s,
-           int num_visis, int num_baselines, int num_times, int num_freqs);
+           int num_cross, int num_baselines, int num_times, int num_freqs);
 
 
 /**

--- a/include/woden_struct_defs.h
+++ b/include/woden_struct_defs.h
@@ -73,9 +73,9 @@ typedef struct _components_t {
 
   //something to store extrapolated output fluxes in
   user_precision_t *extrap_stokesI; /*!< extrapolated COMPONENT Stokes I flux densities (Jy) */
-  user_precision_t *extrap_stokesQ; /*!< extrapolated COMPONENT Stokes I flux densities (Jy) */
-  user_precision_t *extrap_stokesU; /*!< extrapolated COMPONENT Stokes I flux densities (Jy) */
-  user_precision_t *extrap_stokesV; /*!< extrapolated COMPONENT Stokes I flux densities (Jy) */
+  user_precision_t *extrap_stokesQ; /*!< extrapolated COMPONENT Stokes Q flux densities (Jy) */
+  user_precision_t *extrap_stokesU; /*!< extrapolated COMPONENT Stokes U flux densities (Jy) */
+  user_precision_t *extrap_stokesV; /*!< extrapolated COMPONENT Stokes V flux densities (Jy) */
 
   //SHAPELET / GAUSSIAN params
   user_precision_t *shape_coeffs; /*!< Scaling coefficients for SHAPELET basis functions */
@@ -104,13 +104,13 @@ typedef struct _components_t {
   different primary beams for different tiles. At the moment everything is
   the same for each tile, so only have length one for first dimension
   */
-  user_precision_complex_t **gxs; /*!< North-South Beam gain values for all directions,
+  user_precision_complex_t *gxs; /*!< North-South Beam gain values for all directions,
   frequencies, and times for these COMPONENTS*/
-  user_precision_complex_t **Dxs; /*!< North-South Beam leakage values for all directions,
+  user_precision_complex_t *Dxs; /*!< North-South Beam leakage values for all directions,
   frequencies, and times for these COMPONENTS*/
-  user_precision_complex_t **Dys; /*!< East-West Beam leakage values for all directions,
+  user_precision_complex_t *Dys; /*!< East-West Beam leakage values for all directions,
   frequencies, and times for these COMPONENTS*/
-  user_precision_complex_t **gys; /*!< East-West Beam gain values for all directions,
+  user_precision_complex_t *gys; /*!< East-West Beam gain values for all directions,
   frequencies, and times for these COMPONENTS*/
 
   //Leave off the d_ from these device values, as the components_t struct
@@ -254,6 +254,8 @@ typedef struct _woden_settings_t {
   double sdec0;  /*!< Sine of Declination of phase centre (radians)*/
   double cdec0;  /*!< Cosine of Declination of phase centre (radians)*/
   int num_baselines;  /*!< Number of baselines this array layout has */
+  int num_ants;  /*!< Number of antennas this array layout has (MWA calls this
+  number of tiles) */
   int num_freqs;  /*!< Number of frequencies per coarse band*/
   double frequency_resolution;  /*!< Frequency resolution of a fine channel (Hz)*/
   double base_low_freq;  /*!< The lowest fine channel frequency of band 1*/
@@ -279,7 +281,10 @@ typedef struct _woden_settings_t {
   user_precision_t coarse_band_width;  /*!< Frequency bandwidth of a single coarse band (Hz)*/
   double gauss_ra_point;  /*!< The initial Right Ascension to point the Gaussian beam at (radians)*/
   double gauss_dec_point;  /*!< The initial Declination to point the Gaussian beam at (radians)*/
-  int num_visis;  /*!< Total number of visiblities to simulate, so freqs*times*baselines */
+  int num_cross;  /*!< Total number of cross-correlations to simulate, so freqs*times*baselines */
+  int num_autos;  /*!< Total number of auto-correlations to simulate, so freqs*times*baselines */
+  int num_visis;  /*!< Total number of visibilities to simulate, so num_cross + num_autos */
+
   double base_band_freq;  /*!< The lowest fine channel frequency in the current band being simulated*/
   int do_precession; /*!< Boolean of whether to apply precession to the
   array layout or not*/
@@ -288,6 +293,7 @@ typedef struct _woden_settings_t {
   double *latitudes; /*!< Array to hold latitudes for all time centroids (these
     are different when precession is happening)*/
   double *mjds; /*!< Array to hold modified julian dates for all time centroids*/
+  int do_autos; /*!< Boolean of whether to simulate autos or not (0 False, 1 True)*/
 
 } woden_settings_t;
 

--- a/src/add_woden_uvfits.py
+++ b/src/add_woden_uvfits.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+from astropy.io import fits
+import numpy as np
+from sys import exit
+
+
+def check_same_dimensions(hdu1, hdu2):
+    """Bear minimum check that the uvfits data sections are the same size"""
+
+    shape1 = hdu1[0].data.data.shape
+    shape2 = hdu2[0].data.data.shape
+
+    if shape1 != shape2:
+        exit("Shape of the data in the uvfits are not the same. Data "
+             "might have different number of times steps, frequencies, "
+             "or baselines.")
+
+def combine_uvfits(uvfits1, uvfits2, outname):
+    """Opens uvfits1, uvfits2, reads in the visibilities from both, and
+    sums them. Saves the result using the hdu of uvfits1, and leaves the
+    weights of uvfits1 in the outputs. So output data have the array layout
+    of uvfits1, u,v,w of uvfits1 etc, only visibilities are changed"""
+    with fits.open(uvfits1) as hdu1, fits.open(uvfits2) as hdu2:
+
+        check_same_dimensions(hdu1, hdu2)
+
+        data1 = hdu1[0].data.data[:,0,0,:,:,:2]
+        data2 = hdu2[0].data.data[:,0,0,:,:,:2]
+
+        new_data = data1 + data2
+
+        hdu1[0].data.data[:,0,0,:,:,:2] = new_data
+
+        hdu1.writeto(outname, overwrite=True)
+
+def combine_uvfits_bands(uvfits_prepend1, uvfits_prepend2, num_bands, output_name):
+    """Runs `combine_uvfits` on multiple pairs of uvfits, with names generated
+    by adding `{band}.uvfits` onto the end of `uvfits_prepend1` and
+    `uvfits_prepend2`"""
+    for band in range(1, num_bands + 1):
+
+        combine_uvfits(f"{uvfits_prepend1}{band:02d}.uvfits",
+                       f"{uvfits_prepend2}{band:02d}.uvfits",
+                       f"{output_name}{band:02d}.uvfits")
+
+def get_parser():
+    """
+    Runs the argument parser to get command line inputs - used by sphinx and
+    argparse extension to unpack the help below into the online readthedocs
+    documentation.
+
+    Returns
+    -------
+    parser : `argparse.ArgumentParser`
+        The populated argument parser used by `add_woden_uvfits.py`
+
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sum the visibilities in a "
+        "set of uvfits. There are two modes to add uvfits as decribed here. "
+        "Mode 1: Assumes that the uvfits still end in '*{num}.uvfits', and so "
+        "iterates over a given number of bands, so if you have 8 bands "
+        "to combine, you end up with 8 summed uvfits files."
+        "Mode 1 uses the `--num_bands`, `--uvfits_prepend1`, `--uvfits_prepend2`, "
+        "`--output_name_prepend` arguments. Mode 2: This just adds two specific uvfits "
+        "files together via `--uvfits1`, `--uvfits2` and `--output_name` "
+        "DISCLAIMER - only very minimal checks are made that the two sets of "
+        "visibilities make sense to be summed. Add uvfits at your own discretion.")
+
+    band_group = parser.add_argument_group('ADDING COARSE BAND UVFITS')
+    band_group.add_argument('--uvfits_prepend1', default=False,
+        help='Prepend for the first set of uvfits files e.g. ./data/uvdump_')
+    band_group.add_argument('--uvfits_prepend2', default=False,
+        help='Prepend for the second set of uvfits files e.g. ./data2/uvdump_')
+    band_group.add_argument('--output_name_prepend', default="combined_band",
+        help='Name for output summed uvfits file, default: combined_band')
+    band_group.add_argument('--num_bands', default=24, type=int,
+        help='How many pairs of files to combine - default is 24')
+
+    sing_group = parser.add_argument_group('ADDING SINGLE PAIR OF UVFITS')
+    sing_group.add_argument('--uvfits1', default=False,
+        help='Name of the first uvfits file to sum e.g. uvfits1.uvfits')
+    sing_group.add_argument('--uvfits2', default=False,
+        help='Name of the second uvfits file to sum e.g. uvfits2.uvfits')
+    sing_group.add_argument('--output_name', default="combined.uvfits",
+        help='Name for output summed uvfits file, default: combined.uvfits')
+
+    return parser
+
+def check_args(args):
+    """Check that the args returned by """
+
+    if not args.uvfits_prepend1 and not args.uvfits_prepend2 and not args.uvfits1 and not args.uvfits2:
+       exit("You must set either a combination of --uvfits_prepend1 and "
+            "--uvfits_prepend2 or --uvfits1 and --uvfits2 otherwise I don't "
+            "know what to sum")
+
+    if args.uvfits_prepend1 and not args.uvfits_prepend2:
+        exit("If you supply --uvfits_prepend1 you must supply --uvfits_prepend2")
+    if args.uvfits_prepend2 and not args.uvfits_prepend1:
+        exit("If you supply --uvfits_prepend2 you must supply --uvfits_prepend1")
+
+    if args.uvfits1 and not args.uvfits2:
+        exit("If you supply --uvfits1 you must supply --uvfits2")
+    if args.uvfits2 and not args.uvfits1:
+        exit("If you supply --uvfits2 you must supply --uvfits1")
+
+
+def main():
+    """Runs all the things"""
+    parser = get_parser()
+    args = parser.parse_args()
+
+    check_args(args)
+
+    if args.uvfits_prepend1 and args.uvfits_prepend2:
+
+        combine_uvfits_bands(args.uvfits_prepend1, args.uvfits_prepend2,
+                      args.num_bands, args.output_name_prepend)
+    else:
+        combine_uvfits(args.uvfits1, args.uvfits2, args.output_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/concat_woden_uvfits.py
+++ b/src/concat_woden_uvfits.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+from astropy.io import fits
+import numpy as np
+
+def check_uvfits_freq_order(uvfits_prepend, num_bands):
+    """By default, WODEN should output the band numbers in ascending
+    frequency, so check that this is true otherwise things are probably
+    going to go wrong"""
+
+    freqs = []
+
+    for band in range(1, num_bands+1):
+
+        with fits.open(f"{uvfits_prepend}{band:02d}.uvfits") as hdu:
+
+            freqs.append(hdu[0].header['CRVAL4'])
+
+    bands = np.arange(num_bands, dtype=int)
+    freq_order = np.argsort(freqs)
+
+    if np.array_equal(bands, freq_order):
+        pass
+    else:
+        print("WARNING - the order of the frequencies in the uvfits files "
+              "isn't the same as the ordering of the bands. Reordering "
+              "them to be correct, but something is probably wrong and your "
+              "outputs will probably suck.")
+
+    return freq_order
+
+
+def concat_uvfits(uvfits_prepend, bands, output_name):
+    """For band in `band_nums`, make a list of uvfits files with name
+    `{uvfits_prepend}_band{band}.uvfits`. Then concanenate them by frequency,
+    assuming that the set of uvfits are contiguous in frequency. Save output
+    uvfits to `output_name`."""
+
+    num_bands = bands[-1] - bands[0] + 1
+
+    with fits.open(f"{uvfits_prepend}{bands[0]:02d}.uvfits") as hdu:
+        data1 = hdu[0].data.data
+        shape1 = data1.shape
+        orig_hdu = hdu
+
+        uu = hdu[0].data['UU']
+        vv = hdu[0].data['VV']
+        ww = hdu[0].data['WW']
+        date_array = hdu[0].data['DATE'] - hdu[0].header['PZERO4']
+        baselines_array = hdu[0].data['BASELINE']
+
+        ant_hdu = hdu[1]
+
+        num_chans = data1.shape[3]
+
+        all_data = np.empty((data1.shape[0], data1.shape[1], data1.shape[2],
+                             num_bands*num_chans, data1.shape[4], data1.shape[5]))
+
+        all_data[:,:,:,0:num_chans, :, :] = data1
+
+        for band in bands[1:]:
+            with fits.open(f"{uvfits_prepend}{band:02d}.uvfits") as this_hdu:
+                this_data = this_hdu[0].data.data
+
+                base_channel = num_chans*(band - 1)
+                all_data[:,:,:,base_channel:base_channel+num_chans,:,:] = this_data
+
+        uvparnames = ['UU','VV','WW','DATE','BASELINE']
+
+        parvals = [uu, vv, ww, date_array, baselines_array]
+        ##This sets up the new size uvfits
+        uvhdu = fits.GroupData(all_data, parnames=uvparnames, pardata=parvals, bitpix=-32)
+        uvhdu = fits.GroupsHDU(uvhdu)
+
+        uvhdu.header['CTYPE4'] = orig_hdu[0].header['CTYPE4']
+        uvhdu.header['CRVAL4'] = orig_hdu[0].header['CRVAL4']  ##Middle pixel value in Hz
+        uvhdu.header['CRPIX4'] = orig_hdu[0].header['CRPIX4'] ##Middle pixel number
+        uvhdu.header['CDELT4'] = orig_hdu[0].header['CDELT4']
+
+        ##Now just copy across all the old header info to the new header
+        uvhdu.header['PSCAL1'] = orig_hdu[0].header['PSCAL1']
+        uvhdu.header['PZERO1'] = orig_hdu[0].header['PZERO1']
+        uvhdu.header['PSCAL2'] = orig_hdu[0].header['PSCAL2']
+        uvhdu.header['PZERO2'] = orig_hdu[0].header['PZERO2']
+        uvhdu.header['PSCAL3'] = orig_hdu[0].header['PSCAL3']
+        uvhdu.header['PZERO3'] = orig_hdu[0].header['PZERO3']
+        uvhdu.header['PSCAL4'] = orig_hdu[0].header['PSCAL4']
+        uvhdu.header['PZERO4'] = orig_hdu[0].header['PZERO4']
+        uvhdu.header['PSCAL5'] = orig_hdu[0].header['PSCAL5']
+        uvhdu.header['PZERO5'] = orig_hdu[0].header['PZERO5']
+
+        ###uvfits standards
+        uvhdu.header['CTYPE2'] = orig_hdu[0].header['CTYPE2']
+        uvhdu.header['CRVAL2'] = orig_hdu[0].header['CRVAL2']
+        uvhdu.header['CRPIX2'] = orig_hdu[0].header['CRPIX2']
+        uvhdu.header['CDELT2'] = orig_hdu[0].header['CDELT2']
+
+        ##This means it's linearly polarised
+        uvhdu.header['CTYPE3'] = orig_hdu[0].header['CTYPE3']
+        uvhdu.header['CRVAL3'] = orig_hdu[0].header['CRVAL3']
+        uvhdu.header['CRPIX3'] = orig_hdu[0].header['CRPIX3']
+        uvhdu.header['CDELT3'] = orig_hdu[0].header['CDELT3']
+
+
+        uvhdu.header['CTYPE5'] = orig_hdu[0].header['CTYPE5']
+        uvhdu.header['CRVAL5'] = orig_hdu[0].header['CRVAL5']
+        uvhdu.header['CRPIX5'] = orig_hdu[0].header['CRPIX5']
+        uvhdu.header['CDELT5'] = orig_hdu[0].header['CDELT5']
+
+        uvhdu.header['CTYPE6'] = orig_hdu[0].header['CTYPE6']
+        uvhdu.header['CRVAL6'] = orig_hdu[0].header['CRVAL6']
+        uvhdu.header['CRPIX6'] = orig_hdu[0].header['CRPIX6']
+        uvhdu.header['CDELT6'] = orig_hdu[0].header['CDELT6']
+
+        ##We're outputting into J2000
+        uvhdu.header['EPOCH'] = orig_hdu[0].header['EPOCH']
+
+        ##Old observation parameters that were/are needed in CHIPS
+        uvhdu.header['OBJECT']  = orig_hdu[0].header['OBJECT']
+        uvhdu.header['OBSRA']   = orig_hdu[0].header['OBSRA']
+        uvhdu.header['OBSDEC']  = orig_hdu[0].header['OBSDEC']
+
+        uvhdu.header['TELESCOP'] = orig_hdu[0].header['TELESCOP']
+        uvhdu.header['INSTRUME'] = orig_hdu[0].header['INSTRUME']
+        # uvhdu.header['SOFTWARE'] = orig_hdu[0].header['SOFTWARE']
+        uvhdu.header['GITLABEL'] = orig_hdu[0].header['GITLABEL']
+
+        uvhdu.header['DATEOBS'] = orig_hdu[1].header['RDATE']
+
+        uvhdu.header['LAT'] = orig_hdu[0].header['LAT']
+        uvhdu.header['LON'] = orig_hdu[0].header['LON']
+        uvhdu.header['ALT'] = orig_hdu[0].header['ALT']
+        uvhdu.header['INSTRUME'] = orig_hdu[0].header['INSTRUME']
+
+        ## Create hdulist and write out file
+        hdulist = fits.HDUList(hdus=[uvhdu, orig_hdu[1]])
+        hdulist.writeto(output_name, overwrite=True)
+        hdulist.close()
+
+def get_parser():
+    """
+    Runs the argument parser to get command line inputs - used by sphinx and
+    argparse extension to unpack the help below into the online readthedocs
+    documentation.
+
+    Returns
+    -------
+    parser : `argparse.ArgumentParser`
+        The populated argument parser used by `concat_woden_uvfits.py`
+
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Concatenate a number "
+     "of uvfits files by frequency.")
+
+    parser.add_argument('--num_bands', default=24, type=int,
+        help='How many files to concatenate')
+    parser.add_argument('--uvfits_prepend', default=False,
+        help=r'Prepend for the uvfits files e.g. ./data/uvdump_')
+    parser.add_argument('--output_name', default="concanenated.uvfits",
+        help='Name for output concatenated uvfits file, default: concanenated.uvfits')
+
+    return parser
+
+
+def main():
+    """Runs all the things"""
+
+    parser = get_parser()
+    args = parser.parse_args()
+
+    freq_order = check_uvfits_freq_order(args.uvfits_prepend, args.num_bands)
+
+    bands = np.arange(1, args.num_bands+1)
+
+    bands = bands[freq_order]
+
+    concat_uvfits(args.uvfits_prepend, bands, args.output_name)
+
+if __name__ == '__main__':
+
+    main()
+
+
+
+
+
+
+
+
+
+
+#

--- a/src/print_help.c
+++ b/src/print_help.c
@@ -60,4 +60,7 @@ void print_cmdline_help() {
   printf("\t+ no_precession=True: By default, the array layout is precessed back\n");
       printf("\t\tto a J2000 frame to match the sky model. Add this to switch off\n");
       printf("\t\tthis precession \n");
+
+  printf("\t+ do_autos=True: By default, only cross-correlations are calculated\n");
+      printf("\t\tAdd this to include auto-correlations\n");
 }

--- a/src/woden_settings.c
+++ b/src/woden_settings.c
@@ -46,7 +46,8 @@ int read_json_settings(const char *filename,  woden_settings_t *woden_settings){
   struct json_object *array_layout_file_path;
   struct json_object *no_precession;
   struct json_object *MWA_analy;
-  //
+  struct json_object *do_autos_bool;
+
   /* open file */
   if ((fp=fopen(filename,"r"))==NULL) {
     printf("read_json_settings: failed to open json file:\n\t %s \n", filename);
@@ -91,8 +92,10 @@ int read_json_settings(const char *filename,  woden_settings_t *woden_settings){
   json_object_object_get_ex(parsed_json, "hdf5_beam_path", &hdf5_beam_path);
 
   json_object_object_get_ex(parsed_json, "use_EDA2_beam", &EDA2_beam);
-  json_object_object_get_ex(parsed_json, "no_precession", &no_precession);
   json_object_object_get_ex(parsed_json, "use_MWA_analy_beam", &MWA_analy);
+
+  json_object_object_get_ex(parsed_json, "no_precession", &no_precession);
+  json_object_object_get_ex(parsed_json, "do_autos", &do_autos_bool);
 
   //See whether latitude has been set or not
   int lat_true = json_object_get_type(latitude);
@@ -243,6 +246,15 @@ int read_json_settings(const char *filename,  woden_settings_t *woden_settings){
     woden_settings->do_precession = 0;
   } else {
     woden_settings->do_precession = 1;
+  }
+
+  //Boolean whether to calculate auto-correlations or not
+  int do_autos = json_object_get_boolean(do_autos_bool);
+
+  if (do_autos) {
+    woden_settings->do_autos = 1;
+  } else {
+    woden_settings->do_autos = 0;
   }
 
   woden_settings->chunking_size = json_object_get_int64(chunking_size);


### PR DESCRIPTION
Adds in the option to simulate auto-correlations, and adds to helper scripts `add_woden_uvfits.py` and `concat_woden_uvfits.py`, allowing the user to add visibilities from two sets of uvfits, or combine separate coarse band uvfits into a single concatentated uvfits file by frequency.